### PR TITLE
(eicoop) Adds tooltip for expected coop completion time

### DIFF
--- a/eicoop/src/components/CoopCard.vue
+++ b/eicoop/src/components/CoopCard.vue
@@ -152,10 +152,17 @@
         <div class="sm:col-span-1">
           <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Time to complete</dt>
           <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
-            <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
-              formatDuration(leagueStatus.expectedTimeToComplete)
-            }}</span>
-            expected /
+            <tippy class="text-gray-900 dark:text-gray-100">
+              <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
+                formatDuration(leagueStatus.expectedTimeToComplete)
+              }}</span>
+              expected
+              <template v-if="leagueStatus.expectedTimeToComplete > 0" #content>
+                Expected to complete at {{ leagueStatus.expectedFinalCompletionDate.format('YYYY-MM-DD HH:mm') }}.<br />
+                This is an estimate based on the current laying rate (see FAQ below)
+              </template>
+            </tippy>
+            /
             <tippy class="text-gray-900 dark:text-gray-100">
               {{ formatDuration(max(status.secondsRemaining, 0)) }} remaining
               <template #content>

--- a/eicoop/src/components/SoloCard.vue
+++ b/eicoop/src/components/SoloCard.vue
@@ -114,10 +114,16 @@
         <div class="sm:col-span-1">
           <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Time to complete</dt>
           <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
-            <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
-              formatDuration(leagueStatus.expectedTimeToComplete)
-            }}</span>
-            expected /
+            <tippy class="text-gray-900 dark:text-gray-100">
+              <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
+                formatDuration(leagueStatus.expectedTimeToComplete)
+              }}</span>
+              expected
+              <template v-if="leagueStatus.expectedTimeToComplete > 0" #content>
+                Expected to complete at {{ leagueStatus.expectedFinalCompletionDate.format('YYYY-MM-DD HH:mm') }}.<br />
+                This is an estimate based on the current laying rate (see FAQ below)
+              </template>
+            </tippy> /
             <tippy class="text-gray-900 dark:text-gray-100">
               {{ formatDuration(Math.max(leagueStatus.secondsRemaining, 0)) }} remaining
               <template #content>

--- a/eicoop/src/lib/contract.ts
+++ b/eicoop/src/lib/contract.ts
@@ -1,3 +1,4 @@
+import dayjs, { Dayjs } from 'dayjs';
 import { ei, requestFirstContact } from 'lib';
 
 export type ContractType = 'Original' | 'Leggacy';
@@ -98,6 +99,10 @@ export class ContractLeagueStatus {
       this.completionStatus === ContractCompletionStatus.HasCompleted ||
       this.completionStatus === ContractCompletionStatus.HasNoTimeLeft
     );
+  }
+
+  get expectedFinalCompletionDate(): Dayjs {
+    return dayjs().add(this.expectedTimeToComplete, 's');
   }
 
   expectedTimeToCompleteGoal(goal: ei.Contract.IGoal): number {


### PR DESCRIPTION
Simple quality of life addition to the eicoop pages, adding a tooltip above the expected duration, showing the estimated datetime for ending (there was already one for the expire time).

<img src="https://github.com/carpetsage/egg/assets/135384080/6d65e8d2-c53f-4a40-894b-79ea4cd10f1c" width=340/>

This is highly useful in speedrun scenarios where the members always try to check-in right before completion, for CS purposes.

@carpetsage please feel free to comment on code style, organization, etc. (tried to mimic existing code)