### PR TITLE
rockets-tracker: include sensor target information

### DIFF
--- a/lib/missions.ts
+++ b/lib/missions.ts
@@ -9,6 +9,8 @@ import eiafxConfig, { MissionTypeParameters } from './eiafx-config.json';
 import Spaceship = ei.MissionInfo.Spaceship;
 import DurationType = ei.MissionInfo.DurationType;
 import Status = ei.MissionInfo.Status;
+import { Family } from './artifacts/data.json';
+import { getArtifactFamilyProps } from './artifacts';
 
 export const spaceshipList = [
   Spaceship.CHICKEN_ONE,
@@ -221,6 +223,16 @@ export class Mission extends MissionType {
 
   get capacity(): number {
     return this.missionInfo.capacity!;
+  }
+
+  get sensorTarget(): Family | null {
+    const targetId = this.missionInfo.targetArtifact;
+    if (targetId != null) {
+      return getArtifactFamilyProps(targetId);
+    }
+    else {
+      return null;
+    }
   }
 
   get status(): Status {

--- a/wasmegg/rockets-tracker/src/components/ActiveMissionsReport.vue
+++ b/wasmegg/rockets-tracker/src/components/ActiveMissionsReport.vue
@@ -45,7 +45,7 @@
                 {{ mission.durationTypeName }}
               </span>
             </div>
-            <div class="mt-2 text-gray-500 text-xs">Capacity: {{ mission.capacity }}</div>
+            <div class="mt-1 text-gray-500 text-xs">Capacity: {{ mission.capacity }}</div>
             <div class="mt-1 text-gray-500 text-xs">
               Duration:
               <template v-if="mission.durationSeconds !== null">
@@ -53,7 +53,15 @@
               </template>
               <template v-else> &ndash; </template>
             </div>
-            <div class="mt-1 text-gray-700 text-sm font-medium">{{ mission.statusName }}</div>
+            <template v-if="mission.sensorTarget !== null">
+              <div class="mt-1 mb-1 text-gray-500 text-xs">
+                Sensor target:
+              </div>
+              <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
+                {{ mission.sensorTarget.name }}
+              </div>
+            </template>
+            <div class="mt-2 text-gray-700 text-sm font-medium">{{ mission.statusName }}</div>
             <div
               v-if="mission.returnTimestamp !== null"
               v-tippy="{

--- a/wasmegg/rockets-tracker/src/components/ActiveMissionsReport.vue
+++ b/wasmegg/rockets-tracker/src/components/ActiveMissionsReport.vue
@@ -53,14 +53,12 @@
               </template>
               <template v-else> &ndash; </template>
             </div>
-            <template v-if="mission.sensorTarget !== null">
-              <div class="mt-1 mb-1 text-gray-500 text-xs">
-                Sensor target:
-              </div>
-              <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
-                {{ mission.sensorTarget.name }}
-              </div>
-            </template>
+            <div class="mt-1 mb-1 text-gray-500 text-xs">
+              Sensor target:
+            </div>
+            <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
+              {{ mission.sensorTarget?.name ?? "None" }}
+            </div>
             <div class="mt-2 text-gray-700 text-sm font-medium">{{ mission.statusName }}</div>
             <div
               v-if="mission.returnTimestamp !== null"

--- a/wasmegg/rockets-tracker/src/components/MissionDetails.vue
+++ b/wasmegg/rockets-tracker/src/components/MissionDetails.vue
@@ -25,6 +25,12 @@
           <div>{{ mission.durationDisplay }}</div>
           <div class="text-right font-medium">Capacity:</div>
           <div>{{ mission.capacity }}</div>
+          <template v-if="mission.sensorTarget != null">
+            <div class="text-right font-medium mt-0.5">Sensor target:</div>
+            <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
+              {{ mission.sensorTarget.name }}
+            </div>
+          </template>
         </div>
       </div>
     </div>

--- a/wasmegg/rockets-tracker/src/components/MissionDetails.vue
+++ b/wasmegg/rockets-tracker/src/components/MissionDetails.vue
@@ -25,12 +25,10 @@
           <div>{{ mission.durationDisplay }}</div>
           <div class="text-right font-medium">Capacity:</div>
           <div>{{ mission.capacity }}</div>
-          <template v-if="mission.sensorTarget != null">
-            <div class="text-right font-medium mt-0.5">Sensor target:</div>
-            <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
-              {{ mission.sensorTarget.name }}
-            </div>
-          </template>
+          <div class="text-right font-medium mt-0.5">Sensor target:</div>
+          <div class="text-center text-xs text-white rounded-full w-max px-1.5 py-0.5 mx-auto bg-gray-400 font-semibold">
+            {{ mission.sensorTarget?.name ?? "None" }}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Includes sensor target information for the active missions cards:
![image](https://github.com/carpetsage/egg/assets/135384080/cde56ef9-2b88-4c7e-ae5e-a5fa2f7d6a33)

And inside the mission details modal:
<img src="https://github.com/carpetsage/egg/assets/135384080/040bfa53-5102-4e42-bef6-dc230e4f6c00" width="300"/>

A future idea (not implemented) is to permit the user to filter the mission log by target. ex:
<img src="https://github.com/carpetsage/egg/assets/135384080/1a11f363-d1e4-4094-acec-fe1d38fe8e8d" width="300"/>

might be useful later to see how many ships of a given target where sent, their loot, etc.
