### PR TITLE
rockets-tracker: include crafting level information

### DIFF
--- a/lib/artifacts/data.ts
+++ b/lib/artifacts/data.ts
@@ -102,19 +102,19 @@ export const afxCraftingLevelInfos: ei.ArtifactsConfigurationResponse.ICraftingL
   },
   {
     "xpRequired": 2500,
-    "rarityMult": 1.0499999523162842
+    "rarityMult": 1.05
   },
   {
     "xpRequired": 5000,
-    "rarityMult": 1.100000023841858
+    "rarityMult": 1.1
   },
   {
     "xpRequired": 10000,
-    "rarityMult": 1.149999976158142
+    "rarityMult": 1.15
   },
   {
     "xpRequired": 25000,
-    "rarityMult": 1.2000000476837158
+    "rarityMult": 1.2
   },
   {
     "xpRequired": 50000,
@@ -122,19 +122,19 @@ export const afxCraftingLevelInfos: ei.ArtifactsConfigurationResponse.ICraftingL
   },
   {
     "xpRequired": 100000,
-    "rarityMult": 1.2999999523162842
+    "rarityMult": 1.3
   },
   {
     "xpRequired": 250000,
-    "rarityMult": 1.350000023841858
+    "rarityMult": 1.35
   },
   {
     "xpRequired": 500000,
-    "rarityMult": 1.399999976158142
+    "rarityMult": 1.4
   },
   {
     "xpRequired": 1000000,
-    "rarityMult": 1.4500000476837158
+    "rarityMult": 1.45
   },
   {
     "xpRequired": 2000000,
@@ -142,19 +142,19 @@ export const afxCraftingLevelInfos: ei.ArtifactsConfigurationResponse.ICraftingL
   },
   {
     "xpRequired": 4000000,
-    "rarityMult": 1.5499999523162842
+    "rarityMult": 1.55
   },
   {
     "xpRequired": 8000000,
-    "rarityMult": 1.600000023841858
+    "rarityMult": 1.6
   },
   {
     "xpRequired": 15000000,
-    "rarityMult": 1.649999976158142
+    "rarityMult": 1.65
   },
   {
     "xpRequired": 20000000,
-    "rarityMult": 1.7000000476837158
+    "rarityMult": 1.7
   },
   {
     "xpRequired": 35000000,
@@ -162,11 +162,11 @@ export const afxCraftingLevelInfos: ei.ArtifactsConfigurationResponse.ICraftingL
   },
   {
     "xpRequired": 60000000,
-    "rarityMult": 1.850000023841858
+    "rarityMult": 1.85
   },
   {
     "xpRequired": 100000000,
-    "rarityMult": 2
+    "rarityMult": 2,
   },
   {
     "xpRequired": 150000000,

--- a/lib/artifacts/data.ts
+++ b/lib/artifacts/data.ts
@@ -8,6 +8,8 @@ import Name = ei.ArtifactSpec.Name;
 import Level = ei.ArtifactSpec.Level;
 import Type = ei.ArtifactSpec.Type;
 
+export type PlayerCraftingLevel = { level: number, rarityMult: number };
+
 export const allPossibleTiers = data.artifact_families.map(f => f.tiers).flat();
 const familyAfxIdToFamily: Map<Name, Family> = new Map(
   data.artifact_families.map(f => [f.afx_id, f])
@@ -64,3 +66,154 @@ export function getArtifactTierPropsFromId(id: string): Tier {
   }
   return tier;
 }
+
+export function getCraftingLevelFromXp(craftingXp: number): PlayerCraftingLevel {
+  let levelBaseXp = 0;
+  const numLevels = afxCraftingLevelInfos.length;
+
+  for (let level = 1; level < numLevels; ++level) {
+    const { xpRequired, rarityMult } = afxCraftingLevelInfos[level-1];
+
+    if (xpRequired == null || rarityMult == null) {
+      throw new Error(`crafting level ${level} doesn't have valid xpRequired and rarityMult data`)
+    }
+
+    const levelTargetXp = levelBaseXp + xpRequired;
+
+    if (craftingXp <= levelTargetXp || level == numLevels) {
+      return { level, rarityMult };
+    }
+
+    levelBaseXp += xpRequired;
+  }
+
+  // @ts-ignore will return above
+  return undefined;
+}
+
+
+// This info was extracted from a manual API call to afx/config on 2023-06-14
+// TODO: This should come from the data.json generation pipeline,
+// need to refactor the Go tool to include this
+export const afxCraftingLevelInfos: ei.ArtifactsConfigurationResponse.ICraftingLevelInfo[] = [
+  {
+    "xpRequired": 500,
+    "rarityMult": 1
+  },
+  {
+    "xpRequired": 2500,
+    "rarityMult": 1.0499999523162842
+  },
+  {
+    "xpRequired": 5000,
+    "rarityMult": 1.100000023841858
+  },
+  {
+    "xpRequired": 10000,
+    "rarityMult": 1.149999976158142
+  },
+  {
+    "xpRequired": 25000,
+    "rarityMult": 1.2000000476837158
+  },
+  {
+    "xpRequired": 50000,
+    "rarityMult": 1.25
+  },
+  {
+    "xpRequired": 100000,
+    "rarityMult": 1.2999999523162842
+  },
+  {
+    "xpRequired": 250000,
+    "rarityMult": 1.350000023841858
+  },
+  {
+    "xpRequired": 500000,
+    "rarityMult": 1.399999976158142
+  },
+  {
+    "xpRequired": 1000000,
+    "rarityMult": 1.4500000476837158
+  },
+  {
+    "xpRequired": 2000000,
+    "rarityMult": 1.5
+  },
+  {
+    "xpRequired": 4000000,
+    "rarityMult": 1.5499999523162842
+  },
+  {
+    "xpRequired": 8000000,
+    "rarityMult": 1.600000023841858
+  },
+  {
+    "xpRequired": 15000000,
+    "rarityMult": 1.649999976158142
+  },
+  {
+    "xpRequired": 20000000,
+    "rarityMult": 1.7000000476837158
+  },
+  {
+    "xpRequired": 35000000,
+    "rarityMult": 1.75
+  },
+  {
+    "xpRequired": 60000000,
+    "rarityMult": 1.850000023841858
+  },
+  {
+    "xpRequired": 100000000,
+    "rarityMult": 2
+  },
+  {
+    "xpRequired": 150000000,
+    "rarityMult": 2.25
+  },
+  {
+    "xpRequired": 200000000,
+    "rarityMult": 2.5
+  },
+  {
+    "xpRequired": 250000000,
+    "rarityMult": 3
+  },
+  {
+    "xpRequired": 300000000,
+    "rarityMult": 3.5
+  },
+  {
+    "xpRequired": 325000000,
+    "rarityMult": 4
+  },
+  {
+    "xpRequired": 350000000,
+    "rarityMult": 4.5
+  },
+  {
+    "xpRequired": 400000000,
+    "rarityMult": 5
+  },
+  {
+    "xpRequired": 500000000,
+    "rarityMult": 6
+  },
+  {
+    "xpRequired": 600000000,
+    "rarityMult": 7
+  },
+  {
+    "xpRequired": 750000000,
+    "rarityMult": 8
+  },
+  {
+    "xpRequired": 1000000000,
+    "rarityMult": 9
+  },
+  {
+    "xpRequired": 1,
+    "rarityMult": 10
+  }
+];

--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -353,7 +353,12 @@
                 class="inline ml-0.5"
               />
             </dd>
-            <dt class="text-right text-sm font-medium whitespace-nowrap">Crafting XP</dt>
+            <dt
+              v-tippy="{ content: fmtCraftingXpRarityMultiplier(craftingLevel) }"
+              class="text-right text-sm font-medium whitespace-nowrap"
+            >
+              Crafting XP, <span class="text-yellow-500">Level {{ craftingLevel.level }}</span>
+            </dt>
             <dd class="text-left text-sm text-gray-900">{{ fmt(craftingXp) }}</dd>
           </div>
         </div>
@@ -724,6 +729,8 @@ import {
   setLocalStorage,
   TrophyLevel,
   getArtifactTierProps,
+  getCraftingLevelFromXp,
+  PlayerCraftingLevel,
 } from 'lib';
 import BaseInfo from 'ui/components/BaseInfo.vue';
 import {
@@ -928,6 +935,8 @@ const inventoryScore = computed(() => {
 }
 )
 const craftingXp = computed(() => Math.floor(backup.value.artifacts?.craftingXp || 0));
+const craftingLevel = computed(() => getCraftingLevelFromXp(craftingXp.value));
+
 const inventoryConsumptionValue = computed(() =>
   inventoryExpectedFullConsumptionGold(inventory.value as Inventory)
 );
@@ -1027,5 +1036,16 @@ function piggyLevelBonus(level: number): number {
     default:
       return 0.1 * (level + 1);
   }
+}
+
+function fmtCraftingXpRarityMultiplier(craftingLevel: PlayerCraftingLevel): string {
+  const mult = craftingLevel.rarityMult - 1;
+
+  // mimic the way EI shows the increase value on screen
+  const increase = (mult <= 1) ?
+    `${Math.floor(mult * 100)}%` :
+    `${Number(mult.toFixed(2))}x`;
+
+  return `${increase} increase in chance to craft Rare, Epic or Legendary Artifacts`;
 }
 </script>


### PR DESCRIPTION
Include crafting level information on the player details card at rockets-tracker, including a hover text for the rarity multiplier detail.

<img src="https://github.com/carpetsage/egg/assets/135384080/c4520fe9-7171-4a28-ba41-4980dc3aa6b3" width="350"/>

The crafting levels info could be obtained by a `afx/config` call but currently it is not present on the `data.json` file that is auto-generated by the Go code. Seemed non trivial to refactor that part of the code since it appears to use the original go module by mk2. For a first implementation, decided to hardcode the levels


