### PR TITLE
eicoop: add the projected completion time taking into account offline eggs laid

### DIFF
--- a/eicoop/src/components/CoopCard.vue
+++ b/eicoop/src/components/CoopCard.vue
@@ -177,7 +177,14 @@
           </dd>
         </div>
         <div class="sm:col-span-1">
-          <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Time to complete, offline adjusted</dt>
+          <dt class="text-sm font-medium text-gray-500 flex flex-row dark:text-gray-400">
+            Time to complete, offline adjusted
+            <base-warning
+              v-if="anyPlayerPrivate && leagueStatus.expectedTimeToCompleteOfflineAdjusted > 0"
+              v-tippy="'This is a conservative estimate due to some players having private farms'"
+              class="mx-0.5 translate-y-0.5"
+            />
+          </dt>
           <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
               <tippy class="text-gray-900 dark:text-gray-100">
                 <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
@@ -239,6 +246,7 @@ import { completionStatusFgColorClass, completionStatusBgColorClass } from '@/st
 import { devmodeKey } from '@/symbols';
 import { eggTooltip } from '@/utils';
 import BaseIcon from 'ui/components/BaseIcon.vue';
+import BaseWarning from 'ui/components/BaseWarning.vue';
 import ContractLeagueLabel from '@/components/ContractLeagueLabel.vue';
 import ContractGradeLabel from '@/components/ContractGradeLabel.vue';
 import ContractStatusLabel from '@/components/ContractStatusLabel.vue';
@@ -252,6 +260,7 @@ import AutoRefreshedRelativeTime from '@/components/AutoRefreshedRelativeTime.vu
 export default defineComponent({
   components: {
     BaseIcon,
+    BaseWarning,
     ContractLeagueLabel,
     ContractGradeLabel,
     ContractStatusLabel,
@@ -278,6 +287,7 @@ export default defineComponent({
     const league = computed(() => status.value.league);
     const grade = computed(() => status.value.grade || 5);
     const leagueStatus = computed(() => status.value.leagueStatus!);
+    const anyPlayerPrivate = computed(() => status.value.contributors.find(c => !c.farmShared) != null);
     const openings = computed(() =>
       Math.max((contract.value.maxCoopSize || 0) - status.value.contributors.length, 0)
     );
@@ -289,6 +299,7 @@ export default defineComponent({
       league,
       grade,
       leagueStatus,
+      anyPlayerPrivate,
       openings,
       formatEIValue,
       formatDuration,

--- a/eicoop/src/components/CoopCard.vue
+++ b/eicoop/src/components/CoopCard.vue
@@ -158,8 +158,12 @@
               }}</span>
               expected
               <template v-if="leagueStatus.expectedTimeToComplete > 0" #content>
-                Expected to complete at {{ leagueStatus.expectedFinalCompletionDate.format('YYYY-MM-DD HH:mm') }}.<br />
-                This is an estimate based on the current laying rate (see FAQ below)
+                <p>Expected to complete at
+                <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">
+                  {{ leagueStatus.expectedFinalCompletionDate.format('YYYY-MM-DD HH:mm') }}
+                </span>.</p>
+                <br />
+                <p>This is an estimate based on the current laying rate (see FAQ below)</p>
               </template>
             </tippy>
             /
@@ -170,6 +174,28 @@
                 {{ status.expirationTime.format('YYYY-MM-DD HH:mm') }}
               </template>
             </tippy>
+          </dd>
+        </div>
+        <div class="sm:col-span-1">
+          <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Time to complete, offline adjusted</dt>
+          <dd class="mt-1 text-sm text-gray-900 dark:text-gray-100">
+              <tippy class="text-gray-900 dark:text-gray-100">
+                <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">{{
+                  formatDuration(leagueStatus.expectedTimeToCompleteOfflineAdjusted)
+                }}</span>
+                expected
+                <template v-if="leagueStatus.expectedTimeToCompleteOfflineAdjusted > 0" #content>
+                  <p>The expected completion time taking into account offline eggs laid for all members is
+                  <span :class="completionStatusFgColorClass(leagueStatus.completionStatus)">
+                    {{ leagueStatus.expectedFinalCompletionDateOfflineAdjusted.format('YYYY-MM-DD HH:mm') }}
+                  </span>.</p>
+                  <br />
+                  <p>Assumes that all players will check-in right before completion.</p>
+                </template>
+                <template v-if="!leagueStatus.hasEnded && leagueStatus.expectedTimeToCompleteOfflineAdjusted <= 0" #content>
+                  <p>The coop should complete after enough members check-in.</p>
+                </template>
+              </tippy>
           </dd>
         </div>
         <div class="sm:col-span-1">

--- a/eicoop/src/lib/contract.ts
+++ b/eicoop/src/lib/contract.ts
@@ -60,12 +60,14 @@ export class ContractLeagueStatus {
   goals: ei.Contract.IGoal[];
   finalTarget: number;
   expectedTimeToComplete: number;
+  expectedTimeToCompleteOfflineAdjusted: number;
   // requiredEggsPerHour is null if already failed.
   requiredEggsPerHour: number | null;
 
   constructor(
     eggsLaid: number,
     eggsPerHour: number,
+    eggsLaidOfflineAdjusted: number,
     secondsRemaining: number,
     goals: ei.Contract.IGoal[],
     status: string
@@ -78,10 +80,13 @@ export class ContractLeagueStatus {
     if (eggsLaid >= this.finalTarget || status === "COMPLETE") {
       this.completionStatus = ContractCompletionStatus.HasCompleted;
       this.expectedTimeToComplete = 0;
+      this.expectedTimeToCompleteOfflineAdjusted = 0;
       this.requiredEggsPerHour = 0;
       return;
     }
     this.expectedTimeToComplete = ((this.finalTarget - eggsLaid) / eggsPerHour) * 3600;
+    this.expectedTimeToCompleteOfflineAdjusted = Math.max(((this.finalTarget - eggsLaidOfflineAdjusted) / eggsPerHour) * 3600, 0); 
+
     if (secondsRemaining <= 0) {
       this.completionStatus = ContractCompletionStatus.HasNoTimeLeft;
       this.requiredEggsPerHour = null;
@@ -103,6 +108,10 @@ export class ContractLeagueStatus {
 
   get expectedFinalCompletionDate(): Dayjs {
     return dayjs().add(this.expectedTimeToComplete, 's');
+  }
+
+  get expectedFinalCompletionDateOfflineAdjusted(): Dayjs {
+    return dayjs().add(this.expectedTimeToCompleteOfflineAdjusted, 's');
   }
 
   expectedTimeToCompleteGoal(goal: ei.Contract.IGoal): number {

--- a/eicoop/src/lib/coop.ts
+++ b/eicoop/src/lib/coop.ts
@@ -51,7 +51,6 @@ export class CoopStatus {
   refreshTime: Dayjs;
   expirationTime: Dayjs;
   eggsLaidOfflineAdjusted: number;
-  expectedTimeToCompleteOfflineAdjusted: number | null;
   status: string;
 
   constructor(cs: ei.IContractCoopStatusResponse) {
@@ -111,7 +110,6 @@ export class CoopStatus {
     for (const contributor of this.contributors) {
       this.eggsLaidOfflineAdjusted += contributor.offlineEggs;
     }
-    this.expectedTimeToCompleteOfflineAdjusted = null;
   }
 
   async resolveContract({
@@ -171,6 +169,7 @@ export class CoopStatus {
     this.leagueStatus = new ContractLeagueStatus(
       this.eggsLaid,
       this.eggsPerHour,
+      this.eggsLaidOfflineAdjusted,
       this.secondsRemaining,
       this.goals,
       this.status,

--- a/eicoop/src/lib/coop.ts
+++ b/eicoop/src/lib/coop.ts
@@ -364,6 +364,7 @@ export class Contributor {
       (boost) => !!boost.boostId && (boost.timeRemaining ?? 0) > 0,
     );
 
+    // when a player is not sharing the farm, we assume there are no offline eggs (conservative)
     this.offlineSeconds = -(contributor.farmInfo?.timestamp ?? 0);
     this.offlineTimeStr = formatSecondsHM(this.offlineSeconds);
     const offlineHours = Math.min(this.offlineSeconds / 3600, 30);

--- a/eicoop/src/lib/solo.ts
+++ b/eicoop/src/lib/solo.ts
@@ -106,7 +106,7 @@ export class SoloStatus {
 
   get confirmedLeagueStatusNow(): ContractLeagueStatus {
     const secondsRemaining = this.expirationTime.diff(dayjs(), 'seconds', true);
-    return new ContractLeagueStatus(this.eggsLaid, this.eggsPerHour, secondsRemaining, this.goals, "");
+    return new ContractLeagueStatus(this.eggsLaid, this.eggsPerHour, this.eggsLaid, secondsRemaining, this.goals, "");
   }
 
   get estimatedLeagueStatusNow(): ContractLeagueStatus {
@@ -122,6 +122,7 @@ export class SoloStatus {
     return new ContractLeagueStatus(
       estimatedEggsLaid,
       this.eggsPerHour,
+      estimatedEggsLaid,
       secondsRemaining,
       this.goals,
       ""

--- a/eicoop/tailwind.config.js
+++ b/eicoop/tailwind.config.js
@@ -22,6 +22,9 @@ module.exports = {
         purple: {
           ...colors.purple,
         },
+        orange: {
+          ...colors.orange
+        },
         'cool-gray': colors.coolGray,
         // Interpolation of gray-700 (#3F3F46) and red-500 (#EF4444).
         'gray-700-red-tint': {

--- a/ui/components/BaseWarning.vue
+++ b/ui/components/BaseWarning.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg
+    class="h-4 w-4 text-orange-400 cursor-help"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+      clip-rule="evenodd"
+    />
+  </svg>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+export default defineComponent({});
+</script>


### PR DESCRIPTION
Adds a projected completion time that takes into account production while the player was offline (uses the recently added `timestamp` field on `PlayerFarmInfo`).

<img src="https://github.com/carpetsage/egg/assets/135384080/852906c5-b0b2-4f1c-b7b8-b132411b0ef0" width="600" />

Hover text with expected date and disclaimer:
<img src="https://github.com/carpetsage/egg/assets/135384080/c73ecc1f-161e-4d12-bebb-6fea79c40486" width="350" />

Behavior when expected = 0s and the coop is running:
<img src="https://github.com/carpetsage/egg/assets/135384080/88465d65-6522-4838-9502-5899d2da97e1" width="350"/>

And with coop done:
<img src="https://github.com/carpetsage/egg/assets/135384080/9ccdf39e-8b61-48e8-b0a8-c92d9432d637" width="350"/>

Message when any of the players have their farm set to private (the projection is innacurate since the timestamp won't be available):
<img src="https://github.com/carpetsage/egg/assets/135384080/34a97f57-2d90-428d-954f-77a844c2028d" width="350"/>






Related to #31 