### PR TITLE
(fix) incorrect shining chance increase display

### DIFF
--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -1039,11 +1039,11 @@ function piggyLevelBonus(level: number): number {
 }
 
 function fmtCraftingXpRarityMultiplier(craftingLevel: PlayerCraftingLevel): string {
-  const mult = craftingLevel.rarityMult - 1;
+  const mult = craftingLevel.rarityMult;
 
   // mimic the way EI shows the increase value on screen
-  const increase = (mult <= 1) ?
-    `${Math.floor(mult * 100)}%` :
+  const increase = (mult < 2) ?
+    `${Math.floor((mult-1) * 100)}%` :
     `${Number(mult.toFixed(2))}x`;
 
   return `${increase} increase in chance to craft Rare, Epic or Legendary Artifacts`;


### PR DESCRIPTION
Small fix to the chance increase display on the crafting level info (was showing incorrect for 2x and above)
<img src="https://github.com/carpetsage/egg/assets/135384080/98f0af11-b52b-40e0-92d8-401ddb9dd974" width="250">

[Reported by @gruntibular](https://discord.com/channels/1096274233128128545/1099530942013505657/1121449133585219684)
