### PR TITLE
(eicoop) update progress bar with the offline adjusted eggs laid estimate

### DIFF
--- a/eicoop/src/components/ContractProgressBar.vue
+++ b/eicoop/src/components/ContractProgressBar.vue
@@ -7,9 +7,9 @@
         :style="{ width: percentage(projectedEggsLaid, leagueStatus.finalTarget) }"
       ></div>
       <div
-        v-if="currentlyEstimatedEggsLaid !== undefined"
+        v-if="eggsLaidOfflineAdjusted !== undefined"
         class="h-full bg-green-350 absolute rounded-full"
-        :style="{ width: percentage(currentlyEstimatedEggsLaid, leagueStatus.finalTarget) }"
+        :style="{ width: percentage(eggsLaidOfflineAdjusted, leagueStatus.finalTarget) }"
       ></div>
       <div
         class="h-full bg-green-500 absolute rounded-full"
@@ -17,20 +17,20 @@
       ></div>
 
       <template #content>
-        confirmed {{ formatEIValue(eggsLaid) }},<br />
+        confirmed: {{ formatEIValue(eggsLaid) }},<br />
         <template
           v-if="
-            currentlyEstimatedEggsLaid &&
-            currentlyEstimatedEggsLaid > eggsLaid &&
+            eggsLaidOfflineAdjusted &&
+            eggsLaidOfflineAdjusted > eggsLaid &&
             eggsLaid < leagueStatus.finalTarget
           "
         >
-          current estimate {{ formatEIValue(currentlyEstimatedEggsLaid) }},<br />
+          current estimate (offline adjusted): {{ formatEIValue(eggsLaidOfflineAdjusted) }},<br />
         </template>
         <template v-if="projectedEggsLaid > eggsLaid && eggsLaid < leagueStatus.finalTarget">
-          projected total {{ formatEIValue(projectedEggsLaid) }},<br />
+          projected total: {{ formatEIValue(projectedEggsLaid) }},<br />
         </template>
-        final target {{ formatEIValue(leagueStatus.finalTarget, { trim: true }) }}
+        final target: {{ formatEIValue(leagueStatus.finalTarget, { trim: true }) }}
       </template>
     </tippy>
     <template v-for="(goal, index) in leagueStatus.goals" :key="index">
@@ -109,7 +109,7 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    currentlyEstimatedEggsLaid: {
+    eggsLaidOfflineAdjusted: {
       type: Number as PropType<number | undefined>,
       default: undefined,
     },

--- a/eicoop/src/components/CoopCard.vue
+++ b/eicoop/src/components/CoopCard.vue
@@ -221,7 +221,10 @@
         </div>
       </dl>
 
-      <contract-progress-bar :eggs-laid="status.eggsLaid" :projected-eggs-laid="status.projectedEggsLaid"
+      <contract-progress-bar
+        :eggs-laid="status.eggsLaid"
+        :eggs-laid-offline-adjusted="status.eggsLaidOfflineAdjusted"
+        :projected-eggs-laid="status.projectedEggsLaid"
         :league-status="leagueStatus" />
     </div>
 

--- a/eicoop/src/components/FrequentlyAskedQuestions.vue
+++ b/eicoop/src/components/FrequentlyAskedQuestions.vue
@@ -10,11 +10,12 @@
           <span
             class="inline-block h-4 w-4 bg-green-500 border border-gray-300 relative top-0.5"
           ></span>
-          is confirmed production; the solid lighter green bar
+          is confirmed production (already checked-in); the solid lighter green bar
           <span
             class="inline-block h-4 w-4 bg-green-350 border border-gray-300 relative top-0.5"
           ></span>
-          is currently estimated production (not available for coops); the striped bar
+          is currently estimated production taking into account how long each member has been offline
+          (i.e., it would be the confirmed value if everyone checked-in now); the striped bar
           <span
             class="inline-block h-4 w-4 ProgressBar--striped border border-gray-300 relative top-0.5"
           ></span>

--- a/eicoop/src/components/FrequentlyAskedQuestions.vue
+++ b/eicoop/src/components/FrequentlyAskedQuestions.vue
@@ -21,7 +21,8 @@
           ></span>
           is projected total production before contract expiration. You can hover over or click on
           the progress bar to reveal more details in a tooltip. In general, many UI elements can be
-          hovered over or clicked on to reveal more information.
+          hovered over or clicked on to reveal more information. If you don't see a lighter green bar you may need to
+          disable your Dark Reader or other dark mode browser extension. This site has a dark mode already.
         </dd>
       </div>
 

--- a/eicoop/src/lib/coop.ts
+++ b/eicoop/src/lib/coop.ts
@@ -174,6 +174,10 @@ export class CoopStatus {
       this.goals,
       this.status,
     );
+
+    // After resolving the league status we know what the final target is,
+    // so we adjust our offline eggs to keep it within bounds
+    this.eggsLaidOfflineAdjusted = Math.min(this.eggsLaidOfflineAdjusted, this.leagueStatus.finalTarget);
   }
 
   async resolveGrade(

--- a/eicoop2/src/components/ContractProgressBar.vue
+++ b/eicoop2/src/components/ContractProgressBar.vue
@@ -7,9 +7,9 @@
         :style="{ width: percentage(projectedEggsLaid, leagueStatus.finalTarget) }"
       ></div>
       <div
-        v-if="currentlyEstimatedEggsLaid !== undefined"
+        v-if="eggsLaidOfflineAdjusted !== undefined"
         class="h-full bg-green-350 absolute rounded-full"
-        :style="{ width: percentage(currentlyEstimatedEggsLaid, leagueStatus.finalTarget) }"
+        :style="{ width: percentage(eggsLaidOfflineAdjusted, leagueStatus.finalTarget) }"
       ></div>
       <div
         class="h-full bg-green-500 absolute rounded-full"
@@ -20,12 +20,12 @@
         confirmed {{ formatEIValue(eggsLaid) }},<br />
         <template
           v-if="
-            currentlyEstimatedEggsLaid &&
-            currentlyEstimatedEggsLaid > eggsLaid &&
+            eggsLaidOfflineAdjusted &&
+            eggsLaidOfflineAdjusted > eggsLaid &&
             eggsLaid < leagueStatus.finalTarget
           "
         >
-          current estimate {{ formatEIValue(currentlyEstimatedEggsLaid) }},<br />
+          current estimate {{ formatEIValue(eggsLaidOfflineAdjusted) }},<br />
         </template>
         <template v-if="projectedEggsLaid > eggsLaid && eggsLaid < leagueStatus.finalTarget">
           projected total {{ formatEIValue(projectedEggsLaid) }},<br />
@@ -109,7 +109,7 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    currentlyEstimatedEggsLaid: {
+    eggsLaidOfflineAdjusted: {
       type: Number as PropType<number | undefined>,
       default: undefined,
     },


### PR DESCRIPTION
This a simple update for ContractProgressBar to start showing the offline adjusted eggs laid estimate. It reuses a progress bar definition that was already present.

Looks like this (the solid light green bar is the offline adjusted estimate):
<img src="https://github.com/carpetsage/egg/assets/135384080/7dd2293c-3c7c-410d-adab-2c340c061118)" width="600">


Also a small FAQ update to reflect the change:
<img src="https://github.com/carpetsage/egg/assets/135384080/e0d53f96-bbe6-43be-aa5a-252043cefc82)" width="600">


