### PR TITLE
New drop data

### DIFF
--- a/wasmegg/rockets-tracker/src/App.vue
+++ b/wasmegg/rockets-tracker/src/App.vue
@@ -8,11 +8,10 @@
   <div class="max-w-5xl w-full pb-6 mx-auto">
     <the-player-id-form :player-id="playerId" @submit="submitPlayerId" />
 
-    <mission-drop-data-opt-in-form :event-bus="eventBus" :player-id="playerId" class="mx-4 xl:mx-0 my-4" />
-    <legendaries-study-opt-in-form :event-bus="eventBus" class="mx-4 xl:mx-0 my-4" />
-
     <!-- Use a key to recreate on data loading -->
     <base-error-boundary v-if="playerId" :key="`${playerId}:${refreshId}`">
+      <mission-drop-data-opt-in-form :event-bus="eventBus" :player-id="playerId" class="mx-4 xl:mx-0 my-4" />
+      <legendaries-study-opt-in-form :event-bus="eventBus" class="mx-4 xl:mx-0 my-4" />
       <suspense>
         <template #default>
           <the-report :player-id="playerId" :event-bus="eventBus" />
@@ -70,19 +69,21 @@ export default defineComponent({
       playerId.value = id;
       refreshId.value = Date.now();
       savePlayerID(id);
+      if (missionDataPref.value) {
+        console.log(`pref: ${missionDataPref.value}`);
+        recordData(missionDataPref.value);
+      }
     };
     const eventBus = mitt();
     const recordData = (pref: string) => {
       const optin = pref.toLocaleLowerCase() === 'true';
       // change preference if url parameter is different from localstorage
-      if (optin !== getMissionDataPreference(playerId.value) && pref != '') {
-        recordMissionDataPreference(optin,playerId.value);
-        if (optin) {
-          eventBus.emit(REPORT_MISSIONDATA);
-        }
+      recordMissionDataPreference(playerId.value, optin);
+      if (optin) {
+        eventBus.emit(REPORT_MISSIONDATA);
       }
     };
-    recordData(missionDataPref.value);
+    console.log(`pref: ${missionDataPref.value}`);
     return {
       playerId,
       refreshId,

--- a/wasmegg/rockets-tracker/src/App.vue
+++ b/wasmegg/rockets-tracker/src/App.vue
@@ -8,7 +8,7 @@
   <div class="max-w-5xl w-full pb-6 mx-auto">
     <the-player-id-form :player-id="playerId" @submit="submitPlayerId" />
 
-    <mission-drop-data-opt-in-form :event-bus="eventBus" class="mx-4 xl:mx-0 my-4" />
+    <mission-drop-data-opt-in-form :event-bus="eventBus" :player-id="playerId" class="mx-4 xl:mx-0 my-4" />
     <legendaries-study-opt-in-form :event-bus="eventBus" class="mx-4 xl:mx-0 my-4" />
 
     <!-- Use a key to recreate on data loading -->
@@ -36,6 +36,7 @@
 import { defineComponent, ref } from 'vue';
 import mitt from 'mitt';
 
+import { sha256 } from "js-sha256";
 import { getSavedPlayerID, savePlayerID } from 'lib';
 import LegendariesStudyOptInForm from '@/components/LegendariesStudyOptInForm.vue';
 import MissionDropDataOptInForm from '@/components/MissionDropDataOptInForm.vue';
@@ -74,8 +75,8 @@ export default defineComponent({
     const recordData = (pref: string) => {
       const optin = pref.toLocaleLowerCase() === 'true';
       // change preference if url parameter is different from localstorage
-      if (optin !== getMissionDataPreference() && pref != '') {
-        recordMissionDataPreference(optin);
+      if (optin !== getMissionDataPreference(playerId.value) && pref != '') {
+        recordMissionDataPreference(optin,playerId.value);
         if (optin) {
           eventBus.emit(REPORT_MISSIONDATA);
         }
@@ -86,6 +87,7 @@ export default defineComponent({
       playerId,
       refreshId,
       eventBus,
+      sha256,
       submitPlayerId,
     };
   },

--- a/wasmegg/rockets-tracker/src/components/MissionDropDataOptInForm.vue
+++ b/wasmegg/rockets-tracker/src/components/MissionDropDataOptInForm.vue
@@ -34,7 +34,7 @@
       </div>
     </div>
   </template>
-  
+
   <script lang="ts">
   import { defineComponent, PropType, ref, toRefs } from 'vue';
   import { Emitter } from 'mitt';
@@ -46,13 +46,17 @@
         type: Object as PropType<Emitter<Record<typeof REPORT_MISSIONDATA, unknown>>>,
         required: true,
       },
+      playerId: {
+        type: String,
+        required: true,
+      }
     },
     setup(props) {
-      const { eventBus } = toRefs(props);
-      const preferenceOnFile = ref(getMissionDataPreference() !== null);
+      const { eventBus, playerId } = toRefs(props);
+      const preferenceOnFile = ref(getMissionDataPreference(playerId.value) !== null);
       const showDetails = ref(false);
       const record = (optin: boolean) => {
-        recordMissionDataPreference(optin);
+        recordMissionDataPreference(optin, playerId.value);
         preferenceOnFile.value = true;
         if (optin) {
           eventBus.value.emit(REPORT_MISSIONDATA);
@@ -66,7 +70,7 @@
     },
   });
   </script>
-  
+
   <style lang="postcss" scoped>
   .animate-bg-pulse {
     animation: bg-pulse 2s infinite;

--- a/wasmegg/rockets-tracker/src/components/MissionDropDataOptInForm.vue
+++ b/wasmegg/rockets-tracker/src/components/MissionDropDataOptInForm.vue
@@ -3,8 +3,8 @@
       <h3 class="text-sm font-medium text-green-800">Contribute to mission drop data</h3>
       <div class="mt-2 text-sm text-green-700">
         <p>
-          Opt in to contribute your past ship's drops to @mennoo's drop data collection tool
-          All drop rates shown in Artifact Explorer will come from this tool. Opt-in to help improve
+          Opt in to contribute your past ship's drops to @mennoo's drop data collection tool.<br />
+          All drop rates shown in Artifact Explorer come from data submitted to this tool. Opt-in to help improve
           this data.
         </p>
         <p v-if="!showDetails" class="mt-2 underline cursor-pointer" @click="showDetails = true">
@@ -53,10 +53,10 @@
     },
     setup(props) {
       const { eventBus, playerId } = toRefs(props);
-      const preferenceOnFile = ref(getMissionDataPreference(playerId.value) !== null);
+      const preferenceOnFile = ref(getMissionDataPreference(playerId.value) !== undefined);
       const showDetails = ref(false);
       const record = (optin: boolean) => {
-        recordMissionDataPreference(optin, playerId.value);
+        recordMissionDataPreference(playerId.value, optin);
         preferenceOnFile.value = true;
         if (optin) {
           eventBus.value.emit(REPORT_MISSIONDATA);

--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -706,19 +706,25 @@
         <div v-if="!collapsed" class="py-2">
           <div class="grid gap-x-2 justify-center" :style="{ gridTemplateColumns: '50% 50%' }">
             <dt class="text-right text-sm font-medium whitespace-nowrap">Mission Data Opt In:</dt>
-            <dd class="text-left text-sm text-gray-900">{{ getMissionDataPreference(userId) }}</dd>
+            <dd class="text-left text-sm text-gray-900">{{ contributor }}</dd>
 
             <dt class="text-right text-sm font-medium whitespace-nowrap">Last Contributed:</dt>
-            <dd class="text-left text-sm text-gray-900">{{ lastContribution }}</dd>
+            <dd class="text-left text-sm text-gray-900">
+              {{ dayjs(contributionTime).fromNow() }}
+              <base-info
+                v-tippy="{
+                  content: `Rockets tracker only submits your data once every 24 hours`,
+                }"
+                class="inline ml-0.5"
+              />
+              </dd>
 
-          <a
-            :href="`https://eicoop-carpet.netlify.app/u/${userId}`"
-            target="_blank"
-            class="flex items-center justify-center space-x-0.5 text-xs text-gray-500 hover:text-gray-600 mt-1"
-          >
-            <span class="underline">Your contract dashboard</span>
-          </a>
           </div>
+          <button
+            class="items-center justify-center space-x-0.5 text-sm text-gray-500 hover:text-gray-600 mt-1 underline"
+            @click="toggleContribution()">
+            Toggle Mission Data Opt-In
+          </button>
         </div>
       </div>
     </div>
@@ -751,7 +757,7 @@ import {
   PlayerCraftingLevel,
 } from 'lib';
 import BaseInfo from 'ui/components/BaseInfo.vue';
-import { getMissionDataPreference, getMissionDataSubmitTime } from '../lib/missiondata';
+import { getMissionDataPreference, getMissionDataSubmitTime, recordMissionDataPreference } from '../lib/missiondata';
 import {
   getCompletedExtendedHenerprises,
   getLaunchedMissions,
@@ -1035,10 +1041,15 @@ const zeroLegendaryUnconditionallyUnworthyNickname = computed(() =>
 );
 const randIndex = Math.floor(Math.random() * 10000);
 const gradeName = ["None", "C", "B", "A", "AA", "AAA"];
-const lastContribution = computed(() => {
-  const date = getMissionDataSubmitTime(userId.value);
-  return date > 0 ? dayjs(date).format('MMM DD') : 'Never';
-});
+
+// Toggle opt in for menno's data collection
+const optin = ref(getMissionDataPreference(userId.value));
+const contributor = computed(() => optin.value ? "Yes" : "No");
+const toggleContribution = () => {
+  optin.value = !optin.value;
+  recordMissionDataPreference(userId.value,optin.value)
+};
+const contributionTime = ref(getMissionDataSubmitTime(userId.value));
 
 function fmt(n: number): string {
   return n.toLocaleString('en-US');

--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -702,6 +702,24 @@
             <dd class="text-left text-sm text-gray-900">{{ fmt(lifetimeVidDoubler) }}</dd>
           </div>
         </div>
+
+        <div v-if="!collapsed" class="py-2">
+          <div class="grid gap-x-2 justify-center" :style="{ gridTemplateColumns: '50% 50%' }">
+            <dt class="text-right text-sm font-medium whitespace-nowrap">Mission Data Opt In:</dt>
+            <dd class="text-left text-sm text-gray-900">{{ getMissionDataPreference(userId) }}</dd>
+
+            <dt class="text-right text-sm font-medium whitespace-nowrap">Last Contributed:</dt>
+            <dd class="text-left text-sm text-gray-900">{{ lastContribution }}</dd>
+
+          <a
+            :href="`https://eicoop-carpet.netlify.app/u/${userId}`"
+            target="_blank"
+            class="flex items-center justify-center space-x-0.5 text-xs text-gray-500 hover:text-gray-600 mt-1"
+          >
+            <span class="underline">Your contract dashboard</span>
+          </a>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -733,6 +751,7 @@ import {
   PlayerCraftingLevel,
 } from 'lib';
 import BaseInfo from 'ui/components/BaseInfo.vue';
+import { getMissionDataPreference, getMissionDataSubmitTime } from '../lib/missiondata';
 import {
   getCompletedExtendedHenerprises,
   getLaunchedMissions,
@@ -1016,6 +1035,10 @@ const zeroLegendaryUnconditionallyUnworthyNickname = computed(() =>
 );
 const randIndex = Math.floor(Math.random() * 10000);
 const gradeName = ["None", "C", "B", "A", "AA", "AAA"];
+const lastContribution = computed(() => {
+  const date = getMissionDataSubmitTime(userId.value);
+  return date > 0 ? dayjs(date).format('MMM DD') : 'Never';
+});
 
 function fmt(n: number): string {
   return n.toLocaleString('en-US');


### PR DESCRIPTION
* Bottom of the player card on rockets tracker now shows you whether you're opted in, when you last contributed, and has a button you can click to toggle your opt-in state easily
* Opt in by link: <https://wasmegg-carpet.netlify.app/rockets-tracker/?contribute=true> (or set to false to opt out)
* Opt-in preference is now attached to your eid, so if you use multiple accounts you will need to opt in (or out) with each of them.
* Move localstorage variables for opt-in preference and last ship sent to global scope to prep for data submission from any tool