### PR TITLE
fix: Enlightenment EB Calculation to include Seasonal EOP

### DIFF
--- a/wasmegg/enlightenment/src/lib/farmcalc/prophecy_eggs.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/prophecy_eggs.ts
@@ -1,7 +1,6 @@
 import { ei } from 'lib';
 
 export function accountProphecyEggsCount(backup: ei.IBackup): number {
-  
   return (
     trophiesProphecyEggsCount(backup) +
     contractsProphecyEggsCount(backup) +


### PR DESCRIPTION
This pull request includes changes to the `wasmegg/enlightenment/src/lib/farmcalc/prophecy_eggs.ts` file to enhance the calculation of prophecy eggs. The main changes involve adding a new function to account for seasonal prophecy eggs and updating the overall calculation to include this new function.

Enhancements to prophecy eggs calculation:

* [`wasmegg/enlightenment/src/lib/farmcalc/prophecy_eggs.ts`](diffhunk://#diff-391aba9e813fa2796ea4fac7baf14c824dd372b87addcaf9010628230e7a966fR97-R105): Added a new function `seasonalProphecyEggsCount` to calculate prophecy eggs from seasonal events.
* [`wasmegg/enlightenment/src/lib/farmcalc/prophecy_eggs.ts`](diffhunk://#diff-391aba9e813fa2796ea4fac7baf14c824dd372b87addcaf9010628230e7a966fR4-R9): Updated the `accountProphecyEggsCount` function to include the `seasonalProphecyEggsCount` in the total count of prophecy eggs.