### PR TITLE
Add colleggtibles to the Enlightenment Companion

### DIFF
--- a/wasmegg/enlightenment/src/lib/farmcalc/artifacts.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/artifacts.ts
@@ -1,8 +1,9 @@
 import { ei } from 'lib';
 import { artifactSpecToItem } from '../catalog';
 import { clarityEffect, researchPriceMultiplierFromArtifacts } from '../effects';
-import { Artifact, Item, Stone } from '../types';
+import { Artifact, Item, Stone, Colleggtible } from '../types';
 import { requiredWDLevelForEnlightenmentDiamond } from './hab_space';
+import { researchPriceFromColleggtibles } from './colleggtible_eggs';
 
 export function homeFarmArtifacts(backup: ei.IBackup): Artifact[] {
   const db = backup.artifactsDb;
@@ -36,7 +37,8 @@ export function homeFarmArtifacts(backup: ei.IBackup): Artifact[] {
   return artifacts;
 }
 
-export function bestPossibleGussetForEnlightenment(backup: ei.IBackup): Artifact | null {
+export function bestPossibleGussetForEnlightenment(backup: ei.IBackup, colleggtibles: Colleggtible
+): Artifact | null {
   const stonedGussets = artifactsFromInventoryWithClarityStones(
     backup,
     ei.ArtifactSpec.Name.ORNATE_GUSSET
@@ -44,7 +46,7 @@ export function bestPossibleGussetForEnlightenment(backup: ei.IBackup): Artifact
   let bestGusset = null;
   let minRequiredWDLevel = 25;
   for (const gusset of stonedGussets) {
-    const level = requiredWDLevelForEnlightenmentDiamond([gusset]);
+    const level = requiredWDLevelForEnlightenmentDiamond([gusset], colleggtibles);
     if (level < minRequiredWDLevel) {
       bestGusset = gusset;
       minRequiredWDLevel = level;
@@ -53,7 +55,7 @@ export function bestPossibleGussetForEnlightenment(backup: ei.IBackup): Artifact
   return bestGusset;
 }
 
-export function bestPossibleCubeForEnlightenment(backup: ei.IBackup): Artifact | null {
+export function bestPossibleCubeForEnlightenment(backup: ei.IBackup, colleggtibles: Colleggtible): Artifact | null {
   const stonedCubes = artifactsFromInventoryWithClarityStones(
     backup,
     ei.ArtifactSpec.Name.PUZZLE_CUBE
@@ -64,7 +66,7 @@ export function bestPossibleCubeForEnlightenment(backup: ei.IBackup): Artifact |
   let bestCube = null;
   let minPriceMultiplier = 1;
   for (const cube of stonedCubes) {
-    const priceMultiplier = researchPriceMultiplierFromArtifacts([cube]);
+    const priceMultiplier = researchPriceMultiplierFromArtifacts([cube]) * researchPriceFromColleggtibles(colleggtibles);
     if (priceMultiplier < minPriceMultiplier) {
       bestCube = cube;
       minPriceMultiplier = priceMultiplier;

--- a/wasmegg/enlightenment/src/lib/farmcalc/colleggtible_eggs.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/colleggtible_eggs.ts
@@ -1,0 +1,119 @@
+import { ei } from 'lib';
+import { Colleggtible } from '../types';
+
+
+export function earningsFromColleggtibles(dimensionMap: Colleggtible ) {
+    return dimensionMap[ei.GameModifier.GameDimension.EARNINGS] || 1;
+}
+export function awayEarningsFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.AWAY_EARNINGS] || 1;
+}
+
+export function internalHatcheryRateFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.INTERNAL_HATCHERY_RATE] || 1;
+}
+
+export function eggLayingRateFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.EGG_LAYING_RATE] || 1;
+}
+
+export function shippingCapacityFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.SHIPPING_CAPACITY] || 1;
+}
+
+export function habCapacityFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.HAB_CAPACITY] || 1;
+}
+
+export function vehicleCostFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.VEHICLE_COST] || 1;
+}
+
+export function habCostFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.HAB_COST] || 1;
+}
+
+export function researchPriceFromColleggtibles(dimensionMap: Colleggtible) {
+    return dimensionMap[ei.GameModifier.GameDimension.RESEARCH_COST] || 1;
+}
+
+export function getColleggtibleBonuses(backup: ei.IBackup): Colleggtible  {
+    const dimensionMap: Colleggtible = {
+        [ei.GameModifier.GameDimension.INVALID]: 1,
+        [ei.GameModifier.GameDimension.EARNINGS]: 1,
+        [ei.GameModifier.GameDimension.AWAY_EARNINGS]: 1,
+        [ei.GameModifier.GameDimension.INTERNAL_HATCHERY_RATE]: 1,
+        [ei.GameModifier.GameDimension.EGG_LAYING_RATE]: 1,
+        [ei.GameModifier.GameDimension.SHIPPING_CAPACITY]: 1,
+        [ei.GameModifier.GameDimension.HAB_CAPACITY]: 1,
+        [ei.GameModifier.GameDimension.VEHICLE_COST]: 1,
+        [ei.GameModifier.GameDimension.HAB_COST]: 1,
+        [ei.GameModifier.GameDimension.RESEARCH_COST]: 1
+    };
+
+    const contracts = (backup?.contracts?.contracts || []).concat(backup?.contracts?.archive || []);
+    if (contracts.length === 0) {
+        return dimensionMap;
+    }
+    const colleggs = (backup?.contracts?.customEggInfo);
+    if (!colleggs) {
+        return dimensionMap;
+    }
+
+    const eggBonuses: { [key: string]: number } = {};
+
+    for (const contract of contracts) {
+        const props = contract.contract!;
+        const egg = props.egg;
+        const maxFarmSizeReached = contract?.maxFarmSizeReached || 0;
+        if (egg === ei.Egg.CUSTOM_EGG) {
+            const customEggId = props?.customEggId || "unknown";
+
+            if (!eggBonuses[customEggId]) {
+                eggBonuses[customEggId] = maxFarmSizeReached;
+            } else {
+                eggBonuses[customEggId] = Math.max(eggBonuses[customEggId], maxFarmSizeReached);
+            }
+        }
+    }
+
+    for (const customegg of colleggs) {
+        const identifier = customegg?.identifier || "unknown";
+        if (identifier !== "unknown" && eggBonuses[identifier]) {
+            const maxFarmSize = eggBonuses[identifier];
+            const thresholds = [1e7, 1e8, 1e9, 1e10];
+            let index = -1;
+            if (maxFarmSize >= thresholds[0]) {
+                index++;
+            }
+            if (maxFarmSize >= thresholds[1]) {
+                index++;
+            }
+            if (maxFarmSize >= thresholds[2]) {
+                index++;
+            }
+            if (maxFarmSize >= thresholds[3]) {
+                index++;
+            }
+            if (index == -1) {
+                continue;
+            }
+            let buffValue = 1;
+            let eggDimension = ei.GameModifier.GameDimension.INVALID;
+
+            if (customegg.buffs && customegg.buffs[index]) {
+                buffValue = customegg.buffs[index]?.value || 0;
+                eggDimension = customegg.buffs[index]?.dimension || ei.GameModifier.GameDimension.INVALID;
+            }
+
+            if (dimensionMap[eggDimension]?.valueOf() === undefined) {
+                dimensionMap[eggDimension] = buffValue;
+            } else {
+                dimensionMap[eggDimension] *= buffValue;
+            }
+        }
+    }
+
+    //return dimensionMap[dimension] || 1;
+    return dimensionMap;
+}

--- a/wasmegg/enlightenment/src/lib/farmcalc/earnings.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/earnings.ts
@@ -1,34 +1,36 @@
 import { ei } from 'lib';
 import { awayEarningsMultiplier } from '../effects';
-import { Artifact } from '../types';
+import { Artifact, Colleggtible } from '../types';
 import { farmEarningBonus } from './earning_bonus';
 import { farmEggValue, farmEggValueResearches } from './egg_value';
 import { farmEggLayingRate } from './laying_rate';
 import { farmMaxRCB, farmMaxRCBResearches } from './max_rcb';
 import { farmShippingCapacity } from './shipping_capacity';
+import { awayEarningsFromColleggtibles, earningsFromColleggtibles} from './colleggtible_eggs';
 
 export function farmEarningRate(
   backup: ei.IBackup,
   farm: ei.Backup.ISimulation,
   progress: ei.Backup.IGame,
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible,
 ): {
   onlineBaseline: number;
   onlineMaxRCB: number;
   offline: number;
 } {
   const eggValue = farmEggValue(farmEggValueResearches(farm), artifacts);
-  const eggLayingRate = farmEggLayingRate(farm, progress, artifacts);
-  const shippingCapacity = farmShippingCapacity(farm, progress, artifacts);
+  const eggLayingRate = farmEggLayingRate(farm, progress, artifacts, colleggtibles);
+  const shippingCapacity = farmShippingCapacity(farm, progress, artifacts, colleggtibles);
   const earningBonus = farmEarningBonus(backup, farm, progress, artifacts);
-  const onlineBaseline = eggValue * Math.min(eggLayingRate, shippingCapacity) * earningBonus;
+  const onlineBaseline = eggValue * Math.min(eggLayingRate, shippingCapacity) * earningBonus * earningsFromColleggtibles(colleggtibles);
   const maxRCB = farmMaxRCB(farmMaxRCBResearches(farm, progress), artifacts);
   const onlineMaxRCB = onlineBaseline * maxRCB;
   // Standard permit earnings halved while offline.
   const offline =
-    onlineBaseline * (progress.permitLevel === 1 ? 1 : 0.5) * awayEarningsMultiplier(artifacts);
+    onlineBaseline * (progress.permitLevel === 1 ? 1 : 0.5) * awayEarningsMultiplier(artifacts) * awayEarningsFromColleggtibles(colleggtibles);
   return {
-    onlineBaseline,
+    onlineBaseline, 
     onlineMaxRCB,
     offline,
   };

--- a/wasmegg/enlightenment/src/lib/farmcalc/farm_value.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/farm_value.ts
@@ -21,24 +21,26 @@ export function calculateFarmValue(
   backup: ei.IBackup,
   farm: ei.Backup.ISimulation,
   progress: ei.Backup.IGame,
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Record<ei.GameModifier.GameDimension, number>
 ): number {
   // All calculations need to be done with no artifacts, except a flat bonus
   // from Mercury's lens if equipped.
   const population = farm.numChickens! as number;
-  const shippingCapacity = farmShippingCapacity(farm, progress, []);
-  const eggLayingRate = farmEggLayingRate(farm, progress, []);
+  const shippingCapacity = farmShippingCapacity(farm, progress, [], colleggtibles);
+  const eggLayingRate = farmEggLayingRate(farm, progress, [], colleggtibles);
   const populationEffective = Math.floor(
     population * Math.min(1, shippingCapacity / eggLayingRate)
   );
   const populationUndeliverable = population - populationEffective;
-  const totalHabCapacity = farmHabSpaces(farmHabs(farm), farmHabSpaceResearches(farm), []).reduce(
+  const totalHabCapacity = farmHabSpaces(farmHabs(farm), farmHabSpaceResearches(farm), [], colleggtibles).reduce(
     (total, s) => total + s
   );
   const populationVacant = Math.max(totalHabCapacity - population, 0);
   const internalHatcheryRate = farmInternalHatcheryRates(
     farmInternalHatcheryResearches(farm, progress),
-    []
+    [],
+    colleggtibles
   ).onlineRate;
   const populationProjected = internalHatcheryRate * maxAwayTime(farm, progress);
   const eggConstMultiplier = 20; // 20 for the enlightenment egg.
@@ -62,6 +64,7 @@ export function calculateFarmValue(
       populationVacant ** 0.6 +
       0.25 * populationProjected) *
     farmValueMultiplier(artifacts)
+
   );
 }
 

--- a/wasmegg/enlightenment/src/lib/farmcalc/hab_space.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/hab_space.ts
@@ -1,8 +1,9 @@
 import { habSpaceMultiplier } from '../effects';
 import { ei } from 'lib';
-import { Artifact, Research, ResearchInstance } from '../types';
+import { Artifact, Research, ResearchInstance, Colleggtible } from '../types';
 import { farmResearch, farmResearches } from './common';
 import { fullResearchCostsList } from './research_price';
+import { habCapacityFromColleggtibles } from './colleggtible_eggs';
 
 type HabId = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18;
 
@@ -197,7 +198,8 @@ export function farmHabSpaceResearches(farm: ei.Backup.ISimulation): HabSpaceRes
 export function farmHabSpaces(
   habs: Hab[],
   researches: HabSpaceResearchInstance[],
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible
 ): number[] {
   let universalMultiplier = 1;
   let portalOnlyMultiplier = 1;
@@ -216,9 +218,9 @@ export function farmHabSpaces(
       hab.baseHabSpace *
         universalMultiplier *
         (isPortalHab(hab) ? portalOnlyMultiplier : 1) *
-        artifactsMultiplier
+        artifactsMultiplier *
+        habCapacityFromColleggtibles(colleggtibles))
     )
-  );
 }
 
 export function farmCurrentWDLevel(farm: ei.Backup.ISimulation): number {
@@ -232,7 +234,9 @@ export function farmCurrentWDLevel(farm: ei.Backup.ISimulation): number {
 
 // Wormhole Dampening levels required to reach 10B hab space, assuming max
 // everything else.
-export function requiredWDLevelForEnlightenmentDiamond(artifacts: Artifact[]): number {
+export function requiredWDLevelForEnlightenmentDiamond(artifacts: Artifact[], 
+  colleggtibles: Colleggtible
+): number {
   const target = 1e10;
   const finalHab = habVarieties[habVarieties.length - 1];
   const finalHabs = [finalHab, finalHab, finalHab, finalHab];
@@ -242,7 +246,7 @@ export function requiredWDLevelForEnlightenmentDiamond(artifacts: Artifact[]): n
       ...research,
       level: research.maxLevel,
     }));
-  const maxHabSpaceWithoutWD = farmHabSpaces(finalHabs, maxResearchesWithoutWD, artifacts).reduce(
+  const maxHabSpaceWithoutWD = farmHabSpaces(finalHabs, maxResearchesWithoutWD, artifacts, colleggtibles).reduce(
     (total, s) => total + s
   );
   if (maxHabSpaceWithoutWD >= target) {

--- a/wasmegg/enlightenment/src/lib/farmcalc/index.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/index.ts
@@ -11,3 +11,4 @@ export * from './max_rcb';
 export * from './prophecy_eggs';
 export * from './research_price';
 export * from './shipping_capacity';
+export * from './colleggtible_eggs';

--- a/wasmegg/enlightenment/src/lib/farmcalc/internal_hatchery.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/internal_hatchery.ts
@@ -1,7 +1,8 @@
 import { ei } from 'lib';
 import { internalHatcheryRateMultiplier } from '../effects';
-import { Artifact, Research, ResearchInstance } from '../types';
+import { Artifact, Research, ResearchInstance, Colleggtible } from '../types';
 import { farmResearches } from './common';
+import { internalHatcheryRateFromColleggtibles } from './colleggtible_eggs';
 
 export interface InternalHatcheryResearch extends Research {
   multiplicative?: boolean;
@@ -79,7 +80,8 @@ export function farmInternalHatcheryResearches(
 // Rates are measured in chickens/min.
 export function farmInternalHatcheryRates(
   researches: InternalHatcheryResearchInstance[],
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible
 ): {
   onlineRatePerHab: number;
   onlineRate: number;
@@ -105,9 +107,9 @@ export function farmInternalHatcheryRates(
   // With max internal hatchery sharing, four internal hatcheries are constantly
   // at work even if not all habs are bought;
   const onlineRatePerHab = baseRate * onlineMultiplier * artifactsMultiplier;
-  const onlineRate = 4 * onlineRatePerHab;
+  const onlineRate = 4 * onlineRatePerHab * internalHatcheryRateFromColleggtibles(colleggtibles);
   const offlineRatePerHab = onlineRatePerHab * offlineMultiplier;
-  const offlineRate = onlineRate * offlineMultiplier;
+  const offlineRate = onlineRate * offlineMultiplier * internalHatcheryRateFromColleggtibles(colleggtibles);
   return {
     onlineRatePerHab,
     onlineRate,

--- a/wasmegg/enlightenment/src/lib/farmcalc/laying_rate.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/laying_rate.ts
@@ -1,7 +1,8 @@
 import { ei } from 'lib';
 import { eggLayingRateMultiplier } from '../effects';
-import { Artifact, Research, ResearchInstance } from '../types';
+import { Artifact, Research, ResearchInstance, Colleggtible } from '../types';
 import { farmResearches } from './common';
+import { eggLayingRateFromColleggtibles } from './colleggtible_eggs';
 
 type EggLayingRateResearch = Research;
 
@@ -79,10 +80,12 @@ export function farmEggLayingRatePerChicken(
 export function farmEggLayingRate(
   farm: ei.Backup.ISimulation,
   progress: ei.Backup.IGame,
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible
 ): number {
   return (
     (farm.numChickens! as number) *
-    farmEggLayingRatePerChicken(farmEggLayingRateResearches(farm, progress), artifacts)
+    farmEggLayingRatePerChicken(farmEggLayingRateResearches(farm, progress), artifacts) *
+    eggLayingRateFromColleggtibles(colleggtibles)
   );
 }

--- a/wasmegg/enlightenment/src/lib/farmcalc/shipping_capacity.ts
+++ b/wasmegg/enlightenment/src/lib/farmcalc/shipping_capacity.ts
@@ -2,8 +2,9 @@
 
 import { ei } from 'lib';
 import { shippingCapacityMultiplier } from '../effects';
-import { Artifact, Research, ResearchInstance } from '../types';
+import { Artifact, Research, ResearchInstance, Colleggtible } from '../types';
 import { farmResearches } from './common';
+import { shippingCapacityFromColleggtibles } from './colleggtible_eggs';
 
 type VehicleId = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 
@@ -204,7 +205,8 @@ export function farmShippingCapacityResearches(
 export function farmVehicleShippingCapacities(
   vehicles: Vehicle[],
   researches: ShippingCapacityResearchInstance[],
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible
 ): number[] {
   let universalMultiplier = 1;
   let hoverOnlyMultiplier = 1;
@@ -226,18 +228,20 @@ export function farmVehicleShippingCapacities(
       universalMultiplier *
       (isHoverVehicle(vehicle) ? hoverOnlyMultiplier : 1) *
       (isHyperloop(vehicle) ? hyperloopOnlyMultiplier : 1) *
-      artifactsMultiplier
+      artifactsMultiplier *
+      shippingCapacityFromColleggtibles(colleggtibles)
   );
 }
 
 export function farmShippingCapacity(
   farm: ei.Backup.ISimulation,
   progress: ei.Backup.IGame,
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  colleggtibles: Colleggtible
 ): number {
   const vehicles = farmVehicles(farm);
   const researches = farmShippingCapacityResearches(farm, progress);
-  return farmVehicleShippingCapacities(vehicles, researches, artifacts).reduce(
+  return farmVehicleShippingCapacities(vehicles, researches, artifacts, colleggtibles).reduce(
     (total, s) => total + s
   );
 }

--- a/wasmegg/enlightenment/src/lib/types.d.ts
+++ b/wasmegg/enlightenment/src/lib/types.d.ts
@@ -32,3 +32,5 @@ export interface Research {
 export interface ResearchInstance extends Research {
   level: number;
 }
+
+export type Colleggtible = Record<ei.GameModifier.GameDimension, number>;


### PR DESCRIPTION
Added colleggtibles to the Enlightenment Companion. 

Created and populated a Colleggtible data type as a map to hold the GameDimensions used for Colleggtibles. Following what was done with artifacts[] I added parameters to the relevant functions needing to multiply in the colleggtible benefit.

Added a display of the farmers colleggtibles showing only those with multipliers.

<img width="209" alt="Screenshot 2025-01-21 at 5 05 29 PM" src="https://github.com/user-attachments/assets/066a4311-737b-4ab4-8f0e-8bbbbbfd1171" />

