### PR TITLE
bug: Fix Crafting XP for those at level 29

### DIFF
--- a/lib/artifacts/data.ts
+++ b/lib/artifacts/data.ts
@@ -157,7 +157,7 @@ export function validateCraftingLevel(level: number) {
 }
 
 export function getXPFromCraftingLevel(level: number) {
-  if (level >= afxCraftingLevelInfos.length) { return 0; }
+  if (level > afxCraftingLevelInfos.length) { return 0; }
   if (level <= 0) { return afxCraftingLevelInfos[0].xpRequired!; }
 
   const levels = afxCraftingLevelInfos.slice(0,level - 1);


### PR DESCRIPTION
When crafting level is 29, getXPFromCraftingLevel() is called with level+1.

The sanity check on the level needs to permit level 30 so it can properly calculate the remaining experience.

Original Bug:
<img width="333" alt="image" src="https://github.com/user-attachments/assets/8711aad3-dab1-4591-a875-463a7cc60f6e" />

After change:
<img width="358" alt="Screenshot 2025-02-04 at 7 32 03 PM" src="https://github.com/user-attachments/assets/a9d19416-f685-43cc-be81-1667d9d5c22a" />

