### PR TITLE
Modify Crafting XP tippy when level 30

### DIFF
--- a/wasmegg/rockets-tracker/src/components/PlayerCard.vue
+++ b/wasmegg/rockets-tracker/src/components/PlayerCard.vue
@@ -431,7 +431,7 @@
               Crafting XP, <span class="text-yellow-500">Level {{ craftingLevel.level }}</span>
             </dt>
             <dd
-              v-tippy="{ content: fmt(nextLevelXP - craftingXp) }"
+              v-tippy="{ content: craftingLevel.level === 30 ? 'Crafting Legend' : fmt(nextLevelXP - craftingXp) }"
               class="text-left text-sm text-gray-900">
               {{ fmt(craftingXp) }}
             </dd>


### PR DESCRIPTION
When a player reaches crafting level 30 there is no need to show the XP for the next level. Now displaying  'Crafting Legend' in that instance. Crafting Legend is a term used in the game.

<img width="269" alt="Screenshot 2025-02-06 at 7 11 04 AM" src="https://github.com/user-attachments/assets/38dae774-df37-4b45-94df-34c653edb270" />
