### PR TITLE
Fix Eggs Laid alignment after addition of Flame Retardant egg

### DIFF
--- a/wasmegg/eggs-laid/src/components/EggsLaid.vue
+++ b/wasmegg/eggs-laid/src/components/EggsLaid.vue
@@ -102,7 +102,7 @@ function eggsLaid(contracts: ei.ILocalContract[]): number {
 }
 
 function fmtEggTotal(eggTotal: [string, number]) {
-  return `${eggTotal[0].padEnd(14, " ")} - ${fmtApprox(eggTotal[1])}`
+  return `${eggTotal[0].padEnd(15, " ")} - ${fmtApprox(eggTotal[1])}`
 }
 
 function fmtApprox(n: number): string {


### PR DESCRIPTION
Fixes this issue:

![image](https://github.com/user-attachments/assets/f7584a10-0003-46cd-82f6-94c6d09681db)
