### PR TITLE
Fix piggy full consume value actually being GE value for 3 mission slots

### DIFF
--- a/wasmegg/artifact-explorer/src/views/Mission.vue
+++ b/wasmegg/artifact-explorer/src/views/Mission.vue
@@ -184,7 +184,7 @@
           <span class="whitespace-nowrap">
             <span class="text-yellow-500">
                 {{
-              formatToPrecision(selectedLevelExpectedFullConsumptionValuePerDay[0] * 3, precision[0])
+              formatToPrecision(selectedLevelExpectedFullConsumptionValuePerDay[1] * 3, precision[0])
                 }}/d
             </span>
             (3 mission slots)</span>.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/36ffb76c-d356-476d-b0d0-a74332d8243b)

https://discord.com/channels/1096274233128128545/1099530942013505657/1369043662176125029