### PR TITLE
enlightenment: conditionally render TS-only toggle

### DIFF
--- a/wasmegg/enlightenment/src/components/TheCompanion.vue
+++ b/wasmegg/enlightenment/src/components/TheCompanion.vue
@@ -256,7 +256,7 @@
             Cash required to max out the farm (before discounts):
             <base-e-i-value class="text-pink-500" :value="cashTargetACREPreDiscount" />
           </p>
-          <div class="relative flex items-start">
+          <div v-if="cashTargetTSPreDiscount > 0" class="relative flex items-start">
             <div class="flex items-center h-5">
               <input
                 id="target_ts"


### PR DESCRIPTION
This commit adds a condition to the `div` containing the checkbox that
toggles `Show required cash for Timeline Splicing only` to render the
`div` only if `cashTargetTSPreDiscount` is greater than zero.

With this change applied:

<img width="1097" height="253" alt="image" src="https://github.com/user-attachments/assets/b90682f3-213b-4e63-b4cc-f7b72e46b67f" />

