### PR TITLE
chore: ignore `*.swp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 dist.frozen
 .vscode
 __target__
+*.swp


### PR DESCRIPTION
This commit adds an entry to the toplevel `.gitignore` file ignoring Vim
swap files.
