### PR TITLE
Significant upgrade to ELR Impact view on research, and several bugfixes

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -1044,6 +1044,7 @@ async function planNextAscension() {
     shippingCapacityStore.$reset();
     silosStore.$reset();
     notesStore.$reset();
+    virtueStore.setBankValue(0);
 
     // 7. Set starting egg to Curiosity
     virtueStore.setCurrentEgg('curiosity');

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -919,6 +919,8 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
           const earned = teEarnedPerEgg[egg];
           initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - earned));
         }
+
+        farm.lastStepTime = now;
       }
     }
 
@@ -971,6 +973,7 @@ async function quickContinueAscension(selection: 'earnings' | 'elr') {
   try {
     // 1. Reset date/time/TZ to current
     virtueStore.resetToCurrentDateTime();
+    virtueStore.setBankValue(0);
 
     // 3. Refresh backup (submitPlayerId)
     await submitPlayerId(playerId.value, selection === 'earnings' ? 'continue_earnings' : 'continue_elr');

--- a/wasmegg/ascension-planner/src/components/FloatingNotes.vue
+++ b/wasmegg/ascension-planner/src/components/FloatingNotes.vue
@@ -143,7 +143,7 @@ import type { PlannerNote } from '@/stores/notes';
 
 const notesStore = useNotesStore();
 
-const isCollapsed = ref(typeof window !== 'undefined' ? window.innerWidth < 768 : false);
+const isCollapsed = ref(true);
 
 const newNoteText = ref('');
 

--- a/wasmegg/ascension-planner/src/components/actions/ElrViewControls.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ElrViewControls.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex flex-col gap-2 mb-3 p-2.5 bg-gray-50/80 rounded-lg border border-gray-100">
+    <div class="flex items-center gap-3">
+      <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider w-14 shrink-0">View By</span>
+      <div class="flex gap-1 p-0.5 bg-gray-100 rounded-md shadow-inner">
+        <button
+          v-for="option in viewOptions"
+          :key="option.id"
+          @click="$emit('update:viewMode', option.id)"
+          class="px-2.5 py-1 text-[11px] font-medium rounded transition-all whitespace-nowrap"
+          :class="
+            viewMode === option.id
+              ? 'bg-white text-blue-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+          "
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+    <div class="flex items-center gap-3">
+      <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider w-14 shrink-0">Sort By</span>
+      <div class="flex gap-1 p-0.5 bg-gray-100 rounded-md shadow-inner">
+        <button
+          v-for="option in sortOptions"
+          :key="option.id"
+          @click="$emit('update:sortMode', option.id)"
+          class="px-2.5 py-1 text-[11px] font-medium rounded transition-all whitespace-nowrap"
+          :class="
+            sortMode === option.id
+              ? 'bg-white text-blue-600 shadow-sm'
+              : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'
+          "
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { type ElrViewMode, type ElrSortMode } from '@/composables/useResearchViews';
+
+const viewOptions = [
+  { id: 'realistic' as ElrViewMode, label: 'Realistic' },
+  { id: 'potential' as ElrViewMode, label: 'Potential' },
+];
+
+const sortOptions = [
+  { id: 'efficiency' as ElrSortMode, label: 'Time Efficiency' },
+  { id: 'impact' as ElrSortMode, label: 'Impact' },
+];
+
+defineProps<{
+  viewMode: ElrViewMode;
+  sortMode: ElrSortMode;
+}>();
+
+defineEmits(['update:viewMode', 'update:sortMode']);
+</script>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -137,7 +137,7 @@ function getTimeToBuySeconds(research: CommonResearch): number {
  * Buy a single level of research and create the action.
  * Returns true if successful, false if already maxed.
  */
-function buyOneLevel(research: CommonResearch): boolean {
+function buyOneLevel(research: CommonResearch, isSmartBuy: boolean = false): boolean {
   const currentLevel = commonResearchStore.researchLevels[research.id] || 0;
   if (currentLevel >= research.levels) return false;
 
@@ -174,7 +174,7 @@ function buyOneLevel(research: CommonResearch): boolean {
       timestamp: Date.now(),
       type: 'buy_research',
       payload,
-      cost,
+      cost: isSmartBuy ? 0 : cost,
       dependsOn: dependencies,
     },
     beforeSnapshot
@@ -250,7 +250,7 @@ function handleSmartBuy(threshold: number) {
         // Find the first one below threshold
         const found = candidates.find(c => c.seconds <= threshold);
         if (found) {
-          if (buyOneLevel(found.research)) {
+          if (buyOneLevel(found.research, true)) {
             itemBought = true;
           }
         }

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -14,6 +14,44 @@
       {{ viewDescription }}
     </p>
 
+    <ElrViewControls
+      v-if="currentView === 'elr'"
+      :view-mode="elrViewMode"
+      :sort-mode="elrSortMode"
+      @update:view-mode="elrViewMode = $event"
+      @update:sort-mode="elrSortMode = $event"
+    />
+
+    <!-- Realistic Mode Summary -->
+    <div 
+      v-if="currentView === 'elr' && elrViewMode === 'realistic' && realisticSummary"
+      class="mt-2 p-3 bg-gray-50 border border-gray-200 rounded-lg shadow-sm"
+    >
+      <div class="flex flex-wrap justify-center gap-x-6 gap-y-2 text-center">
+        <div class="flex flex-col">
+          <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider leading-none mb-1">Lay Rate</span>
+          <span class="text-sm font-mono font-bold text-gray-900 leading-none py-1" v-tippy="'Optimal artifacts applied, max population assumed'">
+            {{ formatNumber(realisticSummary.layRate) }}/hr
+          </span>
+        </div>
+        <div class="flex flex-col">
+          <span class="text-[10px] font-bold text-gray-400 uppercase tracking-wider leading-none mb-1">Shipping Cap</span>
+          <span class="text-sm font-mono font-bold text-gray-900 leading-none py-1" v-tippy="'Optimal artifacts applied, max vehicles assumed'">
+            {{ formatNumber(realisticSummary.shippingRate) }}/hr
+          </span>
+        </div>
+        <div class="flex flex-col border-l border-gray-200 pl-6">
+          <span class="text-[10px] font-bold text-gray-500 uppercase tracking-wider leading-none mb-1">ELR</span>
+          <span class="text-sm font-mono font-bold text-gray-900 leading-none py-1" v-tippy="'The lower of the two rates'">
+            {{ formatNumber(realisticSummary.elr) }}/hr
+          </span>
+        </div>
+      </div>
+      <p class="mt-2 text-[10px] text-gray-400 text-center italic leading-tight px-2">
+        Note: These stats reflect performance after maxing habs, vehicles, and equipping optimal stone layout.
+      </p>
+    </div>
+
     <!-- Game View (Grouped by Tier) -->
     <ResearchGameView
       v-if="currentView === 'game'"
@@ -65,7 +103,7 @@ import {
   isTierUnlocked,
   type CommonResearch,
 } from '@/calculations/commonResearch';
-import { formatDuration } from '@/lib/format';
+import { formatDuration, formatNumber } from '@/lib/format';
 import { useCommonResearchStore } from '@/stores/commonResearch';
 import { useActionsStore } from '@/stores/actions';
 import { useSalesStore } from '@/stores/sales';
@@ -81,6 +119,7 @@ import SmartBuy from './SmartBuy.vue';
 import ResearchViewSelector from './ResearchViewSelector.vue';
 import ResearchGameView from './ResearchGameView.vue';
 import ResearchFlatView from './ResearchFlatView.vue';
+import ElrViewControls from './ElrViewControls.vue';
 import EventExpiryDialog from '../EventExpiryDialog.vue';
 import { useEventExpiry } from '@/composables/useEventExpiry';
 
@@ -102,6 +141,8 @@ let isSmartBuying = false;
 
 const {
   currentView,
+  elrViewMode,
+  elrSortMode,
   viewDescription,
   costModifiers,
   isResearchSaleActive,
@@ -110,6 +151,7 @@ const {
   tierSummaries,
   gameViewTimes,
   sortedResearches,
+  realisticSummary,
   researchSaleDeadline,
   TIER_THRESHOLDS,
 } = useResearchViews();

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -137,7 +137,7 @@ function getTimeToBuySeconds(research: CommonResearch): number {
  * Buy a single level of research and create the action.
  * Returns true if successful, false if already maxed.
  */
-function buyOneLevel(research: CommonResearch, isSmartBuy: boolean = false): boolean {
+function buyOneLevel(research: CommonResearch): boolean {
   const currentLevel = commonResearchStore.researchLevels[research.id] || 0;
   if (currentLevel >= research.levels) return false;
 
@@ -174,7 +174,7 @@ function buyOneLevel(research: CommonResearch, isSmartBuy: boolean = false): boo
       timestamp: Date.now(),
       type: 'buy_research',
       payload,
-      cost: isSmartBuy ? 0 : cost,
+      cost,
       dependsOn: dependencies,
     },
     beforeSnapshot
@@ -240,7 +240,8 @@ function handleSmartBuy(threshold: number) {
             return {
               research: r,
               price,
-              seconds: getTimeToSave(price, snapshot),
+              // Ignore bank so smart buy never factors in saved gems
+              seconds: getTimeToSave(price, { ...snapshot, bankValue: 0 }),
             };
           });
 
@@ -250,7 +251,7 @@ function handleSmartBuy(threshold: number) {
         // Find the first one below threshold
         const found = candidates.find(c => c.seconds <= threshold);
         if (found) {
-          if (buyOneLevel(found.research, true)) {
+          if (buyOneLevel(found.research)) {
             itemBought = true;
           }
         }

--- a/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
@@ -32,6 +32,7 @@
         :can-buy-to-here="view === 'cheapest' ? true : item.canBuyToHere"
         :buy-to-here-time="item.buyToHereTime"
         :buy-to-here-seconds="item.buyToHereSeconds"
+        :buy-to-here-tooltip="item.buyToHereTooltip"
         :extra-stats="item.extraStats"
         :extra-label="item.extraLabel"
         :extra-seconds="item.extraSeconds"
@@ -67,6 +68,7 @@ interface SortedResearchItem {
   timeToBuySeconds?: number;
   buyToHereTime?: string;
   buyToHereSeconds?: number;
+  buyToHereTooltip?: string;
   canBuyToHere?: boolean;
   showDivider?: boolean;
   unlockTier?: number;

--- a/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
@@ -37,6 +37,7 @@
         :extra-label="item.extraLabel"
         :extra-seconds="item.extraSeconds"
         :hpp="item.hpp"
+        :realistic-stats="item.realisticStats"
         :recommendation-note="item.recommendationNote"
         :show-sale-warning="item.showSaleWarning"
         :show-deadline-warning="item.showDeadlineWarning"
@@ -76,6 +77,7 @@ interface SortedResearchItem {
   extraLabel?: string;
   extraSeconds?: number;
   hpp?: number;
+  realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
   recommendationNote?: string;
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -20,13 +20,13 @@
             {{ research.name }}
           </span>
           <span class="text-[11px] font-medium text-gray-500 whitespace-nowrap hidden sm:inline-block">
-            <span v-if="targetLevel" class="text-blue-600">Lvl {{ targetLevel }}</span>
+            <span v-if="targetLevel" class="text-gray-900">Lvl {{ targetLevel }}</span>
             <span v-else>Lvl {{ currentLevel }}</span>
             / {{ research.levels }}
           </span>
         </div>
         <span class="text-[11px] font-medium text-gray-500 whitespace-nowrap sm:hidden">
-          <span v-if="targetLevel" class="text-blue-600">Lvl {{ targetLevel }}</span>
+          <span v-if="targetLevel" class="text-gray-900">Lvl {{ targetLevel }}</span>
           <span v-else>Lvl {{ currentLevel }}</span>
           / {{ research.levels }}
         </span>
@@ -73,12 +73,12 @@
 
     <!-- Row 3: Metrics, Time Cost, Actions -->
     <div class="flex items-center justify-between w-full pl-[38px] gap-2">
-      <!-- Extra Stats (Left aligned now) -->
+      <!-- Extra Stats (Left aligned) -->
       <div class="flex-1">
         <div v-if="extraStats" class="whitespace-nowrap">
           <div class="flex items-end gap-2">
             <div
-              class="text-[9px] font-bold text-blue-600 uppercase tracking-tighter"
+              class="text-[9px] font-bold text-gray-400 uppercase tracking-tighter"
               :class="{ 'cursor-help': hpp !== undefined }"
               v-tippy="
                 hpp !== undefined
@@ -105,8 +105,8 @@
                 ⚠️
               </span>
             </div>
-            <div v-if="hpp !== undefined" class="text-[9px] font-mono text-purple-600 leading-none pb-[1px]">
-              {{ hpp === Infinity ? '∞' : hpp.toFixed(1) }} hr/%
+            <div v-if="hpp !== undefined" class="text-[9px] font-mono text-gray-400 leading-none pb-[1px]">
+              {{ hpp === Infinity || isNaN(hpp) ? '∞' : hpp.toFixed(1) }} hr/%
             </div>
           </div>
         </div>
@@ -166,13 +166,42 @@
         </div>
       </div>
     </div>
+
+    <!-- Row 4: Realistic Stats Comparison (Conditional) -->
+    <div v-if="realisticStats" class="mt-1 flex items-center justify-between w-full pl-[38px] py-1 border-t border-gray-50">
+       <div class="flex items-center gap-6">
+         <div class="flex flex-col">
+           <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter leading-none mb-1 text-center font-mono">Lay Rate</span>
+           <span class="text-[10px] font-mono font-bold text-gray-600 leading-none text-center">
+             {{ formatNumber(realisticStats.layRate) }}/hr
+           </span>
+         </div>
+         <div class="flex flex-col">
+           <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter leading-none mb-1 text-center font-mono">Shipping Cap</span>
+           <span class="text-[10px] font-mono font-bold text-gray-600 leading-none text-center">
+             {{ formatNumber(realisticStats.shippingRate) }}/hr
+           </span>
+         </div>
+       </div>
+       <div class="text-right">
+         <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter leading-none mb-1 block text-right font-mono">ELR</span>
+         <div class="flex items-center justify-end gap-1 leading-none">
+           <span class="text-[11px] font-mono font-bold text-gray-900">
+             {{ formatNumber(realisticStats.elr) }}/hr
+           </span>
+           <span v-if="realisticStats.elrDelta > 0.001" class="text-[9px] font-mono font-bold text-gray-400 ml-1">
+             (+{{ formatWithReference(realisticStats.elrDelta, realisticStats.elr) }})
+           </span>
+         </div>
+       </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { CommonResearch } from '@/calculations/commonResearch';
-import { formatNumber, formatGemPrice, formatAbsoluteTime } from '@/lib/format';
+import { formatNumber, formatGemPrice, formatAbsoluteTime, formatDuration, formatWithReference } from '@/lib/format';
 import { getResearchIconPath } from '@/lib/assets';
 import { iconURL } from 'lib';
 import { useActionsStore } from '@/stores/actions';
@@ -201,6 +230,7 @@ const props = defineProps<{
   buyToHereSeconds?: number;
   buyToHereTooltip?: string;
   extraSeconds?: number;
+  realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;
 }>();

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -127,7 +127,7 @@
             class="bg-blue-600 text-white hover:bg-blue-700 font-bold uppercase tracking-widest text-[10px] py-1.5 px-3 rounded shadow-sm transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
             :class="showDeadlineWarning ? 'bg-amber-500 hover:bg-amber-600' : ''"
             :disabled="!canBuyToHere"
-            v-tippy="deadlineWarningTooltip(buyToHereSeconds)"
+            v-tippy="deadlineWarningTooltip(buyToHereSeconds, buyToHereTooltip)"
             @click.stop="$emit('buyToHere')"
           >
             Buy to here
@@ -199,6 +199,7 @@ const props = defineProps<{
   timeToBuySeconds?: number;
   maxTimeSeconds?: number;
   buyToHereSeconds?: number;
+  buyToHereTooltip?: string;
   extraSeconds?: number;
   showSaleWarning?: boolean;
   showDeadlineWarning?: boolean;
@@ -214,13 +215,17 @@ const baseTimestamp = computed(() => {
   return startTime + (actionsStore.effectiveSnapshot.lastStepTime - offset) * 1000;
 });
 
-function deadlineWarningTooltip(seconds?: number) {
-  if (seconds === undefined) return '';
+function deadlineWarningTooltip(seconds?: number, extraText?: string) {
+  if (seconds === undefined) return extraText || '';
   const timeStr = formatAbsoluteTime(seconds, baseTimestamp.value, virtueStore.ascensionTimezone);
-  if (props.showDeadlineWarning) {
-    return `${timeStr} is after next Saturday at +0. Turn off the research sale to see realistic prices.`;
+  const warning = props.showDeadlineWarning
+    ? `${timeStr} is after next Saturday at +0. Turn off the research sale to see realistic prices.`
+    : timeStr;
+  
+  if (extraText) {
+    return `${extraText}\n\nEstimated completion: ${warning}`;
   }
-  return timeStr;
+  return warning;
 }
 
 defineEmits<{

--- a/wasmegg/ascension-planner/src/components/actions/SmartBuy.vue
+++ b/wasmegg/ascension-planner/src/components/actions/SmartBuy.vue
@@ -63,6 +63,11 @@
           Always On
         </button>
       </div>
+      
+      <!-- Note -->
+      <p class="text-[10px] text-slate-500 text-center px-2 leading-tight">
+        Note: Smart Buy will never spend gems from your bank.
+      </p>
     </div>
   </div>
 </template>

--- a/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
+++ b/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
@@ -44,7 +44,7 @@
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-0">
           <div>
             <div class="text-sm font-bold text-slate-700">Starting Egg</div>
-            <div class="hidden sm:block text-[10px] uppercase font-black text-slate-400 tracking-wider">Initial virtue candidate</div>
+            <div class="hidden sm:block text-[10px] uppercase font-black text-slate-400 tracking-wider">Initial Egg</div>
           </div>
           <div class="flex gap-2 justify-between w-full sm:w-auto mt-1 sm:mt-0">
             <button
@@ -57,7 +57,7 @@
                   : 'border-slate-100 bg-slate-50 opacity-60 hover:opacity-100 hover:border-slate-200',
               ]"
               v-tippy="VIRTUE_EGG_NAMES[egg]"
-              @click="$emit('set-initial-egg', egg)"
+              @click="handleInitialEggClick(egg)"
             >
               <img
                 :src="iconURL(`egginc/egg_${egg}.png`, 64)"
@@ -652,6 +652,13 @@ const props = defineProps<{
   activeArtifactSet: import('@/types').ArtifactSetName | null;
   colleggtibleTiers: import('@/lib/colleggtibles').ColleggtibleTiers;
 }>();
+
+function handleInitialEggClick(egg: VirtueEgg) {
+  if (props.initialEgg === egg) return;
+  if (confirm('Changing the initial egg will reset your entire plan. Are you sure you want to continue?')) {
+    emit('set-initial-egg', egg);
+  }
+}
 
 const emit = defineEmits<{
   'set-epic-research-level': [researchId: string, level: number];

--- a/wasmegg/ascension-planner/src/composables/useActionExecutor.ts
+++ b/wasmegg/ascension-planner/src/composables/useActionExecutor.ts
@@ -67,8 +67,8 @@ export function useActionExecutor() {
         actionsStore.actions,
         fullAction,
         actionsStore.editingInsertIndex,
-        idsToRemove => {
-          actionsStore.removeActions(idsToRemove);
+        async idsToRemove => {
+          await actionsStore.removeActions(idsToRemove);
         }
       );
 
@@ -79,7 +79,7 @@ export function useActionExecutor() {
       }
 
       // Insert at the correct position and replay subsequent actions
-      actionsStore.insertAction(fullAction, replayAction);
+      await actionsStore.insertAction(fullAction, replayAction);
 
       // Restore to the state after all replays (current state)
       // SKIP restoration if in batch mode - we want to keep the virtual state

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -649,7 +649,9 @@ export function useResearchViews() {
           // (Price / Earnings) = Seconds to buy
           // (Seconds / 3600) = Hours to buy
           // HPP = Hours / (Impact * 100)
-          const secondsToBuy = getTimeToSave(price, actionsStore.effectiveSnapshot);
+          // Use a snapshot with bankValue zeroed so hpp reflects pure earnings time, not savings.
+          const noBankSnapshot = { ...actionsStore.effectiveSnapshot, bankValue: 0 };
+          const secondsToBuy = getTimeToSave(price, noBankSnapshot);
           const hoursToBuy = secondsToBuy / 3600;
           const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
 

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -17,12 +17,19 @@ import { useVirtueStore } from '@/stores/virtue';
 import { computeSnapshot } from '@/engine/compute';
 import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
 import { applyAction, getTimeToSave, calculateEarningsForTime } from '@/engine/apply';
-import { calculateMaxVehicleSlots, calculateMaxTrainLength } from '@/calculations/shippingCapacity';
+import { calculateMaxVehicleSlots, calculateMaxTrainLength, calculateShippingCapacity } from '@/calculations/shippingCapacity';
 import { getNextPacificTime } from '@/lib/events';
 import { type CalculationsSnapshot } from '@/types';
+import { getOptimalELRSet } from '@/lib/artifacts/virtue';
+import { calculateArtifactModifiers } from '@/lib/artifacts';
+import { calculateLayRate } from '@/calculations/layRate';
+import { calculateEffectiveLayRate } from '@/calculations/effectiveLayRate';
+import { calculateHabCapacity_Full } from '@/calculations/habCapacity';
 import { createSimAction } from '@/types/actions/meta';
 
 export type ViewType = 'game' | 'cheapest' | 'roi' | 'elr';
+export type ElrViewMode = 'realistic' | 'potential';
+export type ElrSortMode = 'efficiency' | 'impact';
 
 /**
  * Common interface for research items across different views.
@@ -96,6 +103,56 @@ const ELR_EXCLUDED_CATEGORIES = [
   'egg_value',
 ];
 
+/**
+ * Compute ELR using the full pipeline with given research levels, artifact mods, max habs/vehicles.
+ */
+function computeRealisticELR(
+  researchLevels: Record<string, number>,
+  artifactMods: ReturnType<typeof calculateArtifactModifiers>,
+  epicResearchLevels: Record<string, number>,
+  colleggtibleModifiers: any,
+): { layRate: number; shippingRate: number; effectiveRate: number } {
+  const habCapOutput = calculateHabCapacity_Full({
+    habIds: [18, 18, 18, 18] as (number | null)[],
+    researchLevels,
+    peggMultiplier: colleggtibleModifiers.habCap,
+    artifactMultiplier: artifactMods.habCapacity.totalMultiplier,
+    artifactEffects: artifactMods.habCapacity.effects,
+  });
+  const population = habCapOutput.totalFinalCapacity;
+
+  const layRateOutput = calculateLayRate({
+    researchLevels,
+    epicComfyNestsLevel: epicResearchLevels['epic_egg_laying'] || 0,
+    siliconMultiplier: colleggtibleModifiers.elr,
+    population,
+    artifactMultiplier: artifactMods.eggLayingRate.totalMultiplier,
+    artifactEffects: artifactMods.eggLayingRate.effects,
+  });
+
+  const totalSlots = calculateMaxVehicleSlots(researchLevels);
+  const maxTrainLen = calculateMaxTrainLength(researchLevels);
+  const vehicles = Array(totalSlots).fill(null).map(() => ({ vehicleId: 11, trainLength: maxTrainLen }));
+
+  const shippingOutput = calculateShippingCapacity({
+    vehicles,
+    researchLevels,
+    transportationLobbyistLevel: epicResearchLevels['transportation_lobbyist'] || 0,
+    colleggtibleMultiplier: colleggtibleModifiers.shippingCap,
+    artifactMultiplier: artifactMods.shippingRate.totalMultiplier,
+    artifactEffects: artifactMods.shippingRate.effects,
+  });
+
+  const layRate = layRateOutput.totalRatePerSecond;
+  const shippingRate = shippingOutput.totalFinalCapacity;
+
+  return {
+    layRate,
+    shippingRate,
+    effectiveRate: Math.min(layRate, shippingRate),
+  };
+}
+
 export function useResearchViews() {
   const commonResearchStore = useCommonResearchStore();
   const initialStateStore = useInitialStateStore();
@@ -103,6 +160,32 @@ export function useResearchViews() {
   const virtueStore = useVirtueStore();
 
   const currentView = ref<ViewType>('game');
+  const elrViewMode = ref<ElrViewMode>('realistic');
+  const elrSortMode = ref<ElrSortMode>('efficiency');
+
+  const realisticSummary = computed(() => {
+    const rawBackup = initialStateStore.rawBackup;
+    if (!rawBackup || elrViewMode.value !== 'realistic') return null;
+
+    const researchLevels = commonResearchStore.researchLevels;
+    const context = getSimulationContext();
+    
+    const optimal = getOptimalELRSet(rawBackup, {
+      assumeMaxHabsVehicles: true,
+      excludeGusset: false,
+      commonResearch: researchLevels,
+      epicResearchLevels: context.epicResearchLevels,
+      colleggtibleModifiers: context.colleggtibleModifiers,
+    });
+    const artifactMods = calculateArtifactModifiers(optimal);
+    const stats = computeRealisticELR(researchLevels, artifactMods, context.epicResearchLevels, context.colleggtibleModifiers);
+
+    return {
+      layRate: stats.layRate * 3600,
+      shippingRate: stats.shippingRate * 3600,
+      elr: stats.effectiveRate * 3600,
+    };
+  });
 
   const viewDescription = computed(() => {
     switch (currentView.value) {
@@ -112,8 +195,19 @@ export function useResearchViews() {
         return 'All unpurchased researches sorted by price. Strategically unlock tiers with "Buy to here".';
       case 'roi':
         return 'Prioritizes upgrades that pay for themselves fastest based on your current earnings.';
-      case 'elr':
-        return 'Sorts by theoretical maximum potential impact to Egg Laying Rate, ignoring current bottlenecks.';
+      case 'elr': {
+        const view = elrViewMode.value;
+        const sort = elrSortMode.value;
+        if (view === 'potential' && sort === 'efficiency') {
+          return 'Theoretical max impact to ELR, sorted by time efficiency.';
+        } else if (view === 'potential' && sort === 'impact') {
+          return 'Theoretical max impact to ELR, sorted by total impact.';
+        } else if (view === 'realistic' && sort === 'efficiency') {
+          return 'True ELR impact with optimal artifacts and max habs/vehicles, sorted by time efficiency.';
+        } else {
+          return 'True ELR impact with optimal artifacts and max habs/vehicles, sorted by total impact.';
+        }
+      }
       default:
         return '';
     }
@@ -623,59 +717,147 @@ export function useResearchViews() {
 
     if (currentView.value === 'elr') {
       const researchLevels = commonResearchStore.researchLevels;
-      const currentSlots = calculateMaxVehicleSlots(researchLevels);
-      const currentMaxCars = calculateMaxTrainLength(researchLevels);
 
       const unpurchased = all.filter(r => (researchLevels[r.id] || 0) < r.levels && filterByCategories(r));
       const uniqueUnpurchased = Array.from(new Map(unpurchased.map(r => [r.id, r])).values());
 
-      const currentEarnings = actionsStore.effectiveSnapshot.offlineEarnings;
+      // Build candidate list based on view mode
+      let candidates: {
+        research: CommonResearch;
+        price: number;
+        currentLevel: number;
+        targetLevel: number;
+        timeToBuy: string;
+        canBuy: boolean;
+        isMaxed: boolean;
+        impact: number;
+        hpp: number;
+        realisticStats?: { layRate: number; shippingRate: number; elr: number };
+        showDeadlineWarning: boolean;
+      }[];
 
-      const candidates = uniqueUnpurchased
-        .map(r => {
-          const level = researchLevels[r.id] || 0;
-          const price = getDiscountedVirtuePrice(r, level, mods, isSale);
-          let impact = 0;
+      if (elrViewMode.value === 'realistic') {
+        // Realistic mode: full ELR pipeline with optimal artifacts, max habs/vehicles, gusset included
+        const rawBackup = initialStateStore.rawBackup;
+        if (!rawBackup) return [];
 
-          if (FLEET_RESEARCH_IDS.includes(r.id)) {
-            impact = 1 / currentSlots;
-          } else if (r.id === TRAIN_CAR_RESEARCH_ID) {
-            impact = 1 / currentMaxCars;
-          } else {
-            impact = r.per_level / (1 + level * r.per_level);
-          }
+        const context = getSimulationContext();
+        
+        // Baseline: Optimal artifacts for CURRENT research levels
+        const baselineOptimal = getOptimalELRSet(rawBackup, {
+          assumeMaxHabsVehicles: true,
+          excludeGusset: false,
+          commonResearch: researchLevels,
+          epicResearchLevels: context.epicResearchLevels,
+          colleggtibleModifiers: context.colleggtibleModifiers,
+        });
+        const baselineArtifactMods = calculateArtifactModifiers(baselineOptimal);
+        const baseline = computeRealisticELR(researchLevels, baselineArtifactMods, context.epicResearchLevels, context.colleggtibleModifiers);
 
-          // Hours per percentage point
-          // (Price / Earnings) = Seconds to buy
-          // (Seconds / 3600) = Hours to buy
-          // HPP = Hours / (Impact * 100)
-          // Use a snapshot with bankValue zeroed so hpp reflects pure earnings time, not savings.
-          const noBankSnapshot = { ...actionsStore.effectiveSnapshot, bankValue: 0 };
-          const secondsToBuy = getTimeToSave(price, noBankSnapshot);
-          const hoursToBuy = secondsToBuy / 3600;
-          const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+        if (baseline.effectiveRate <= 0) return [];
 
-          return {
-            research: r,
-            price,
-            currentLevel: level,
-            targetLevel: level + 1,
-            timeToBuy: '',
-            canBuy: isTierUnlocked(researchLevels, r.tier),
-            isMaxed: false,
-            impact,
-            hpp,
-            showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuy > researchSaleDeadline.value),
-          };
-        })
-        .filter(c => c.impact > 0)
-        .sort((a, b) => {
+        candidates = uniqueUnpurchased
+          .map(r => {
+            const level = researchLevels[r.id] || 0;
+            const price = getDiscountedVirtuePrice(r, level, mods, isSale);
+
+            const tempLevels = { ...researchLevels, [r.id]: level + 1 };
+            
+            // Re-calculate OPTIMAL artifacts for THIS research level
+            const tempOptimal = getOptimalELRSet(rawBackup, {
+              assumeMaxHabsVehicles: true,
+              excludeGusset: false,
+              commonResearch: tempLevels,
+              epicResearchLevels: context.epicResearchLevels,
+              colleggtibleModifiers: context.colleggtibleModifiers,
+            });
+            
+            const tempArtifactMods = calculateArtifactModifiers(tempOptimal);
+            const stats = computeRealisticELR(tempLevels, tempArtifactMods, context.epicResearchLevels, context.colleggtibleModifiers);
+            const impact = (stats.effectiveRate - baseline.effectiveRate) / baseline.effectiveRate;
+
+            const noBankSnapshot = { ...actionsStore.effectiveSnapshot, bankValue: 0 };
+            const secondsToBuy = getTimeToSave(price, noBankSnapshot);
+            const hoursToBuy = secondsToBuy / 3600;
+            const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+
+            return {
+              research: r,
+              price,
+              currentLevel: level,
+              targetLevel: level + 1,
+              timeToBuy: '',
+              canBuy: isTierUnlocked(researchLevels, r.tier),
+              isMaxed: false,
+              impact,
+              hpp,
+              realisticStats: {
+                layRate: stats.layRate * 3600,
+                shippingRate: stats.shippingRate * 3600,
+                elr: stats.effectiveRate * 3600,
+                elrDelta: (stats.effectiveRate - baseline.effectiveRate) * 3600,
+              },
+              showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuy > researchSaleDeadline.value),
+            };
+          });
+      } else {
+        // Potential mode: theoretical formula-based impact
+        const currentSlots = calculateMaxVehicleSlots(researchLevels);
+        const currentMaxCars = calculateMaxTrainLength(researchLevels);
+
+        candidates = uniqueUnpurchased
+          .map(r => {
+            const level = researchLevels[r.id] || 0;
+            const price = getDiscountedVirtuePrice(r, level, mods, isSale);
+            let impact = 0;
+
+            if (FLEET_RESEARCH_IDS.includes(r.id)) {
+              impact = 1 / currentSlots;
+            } else if (r.id === TRAIN_CAR_RESEARCH_ID) {
+              impact = 1 / currentMaxCars;
+            } else {
+              impact = r.per_level / (1 + level * r.per_level);
+            }
+
+            // Hours per percentage point
+            // Use a snapshot with bankValue zeroed so hpp reflects pure earnings time, not savings.
+            const noBankSnapshot = { ...actionsStore.effectiveSnapshot, bankValue: 0 };
+            const secondsToBuy = getTimeToSave(price, noBankSnapshot);
+            const hoursToBuy = secondsToBuy / 3600;
+            const hpp = impact > 0 ? hoursToBuy / (impact * 100) : Infinity;
+
+            return {
+              research: r,
+              price,
+              currentLevel: level,
+              targetLevel: level + 1,
+              timeToBuy: '',
+              canBuy: isTierUnlocked(researchLevels, r.tier),
+              isMaxed: false,
+              impact,
+              hpp,
+              showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuy > researchSaleDeadline.value),
+            };
+          })
+          .filter(c => c.impact > 0);
+      }
+
+      // Sort based on elrSortMode
+      if (elrSortMode.value === 'efficiency') {
+        candidates.sort((a, b) => {
           if (a.canBuy !== b.canBuy) return a.canBuy ? -1 : 1;
           if (isFinite(a.hpp) || isFinite(b.hpp)) {
             if (a.hpp !== b.hpp) return a.hpp - b.hpp;
           }
           return b.impact - a.impact;
         });
+      } else {
+        candidates.sort((a, b) => {
+          if (a.canBuy !== b.canBuy) return a.canBuy ? -1 : 1;
+          if (a.impact !== b.impact) return b.impact - a.impact;
+          return a.hpp - b.hpp;
+        });
+      }
 
       return candidates.map(c => ({
         ...c,
@@ -690,6 +872,8 @@ export function useResearchViews() {
 
   return {
     currentView,
+    elrViewMode,
+    elrSortMode,
     viewDescription,
     costModifiers,
     isResearchSaleActive,
@@ -698,6 +882,7 @@ export function useResearchViews() {
     tierSummaries,
     gameViewTimes,
     sortedResearches,
+    realisticSummary,
     researchSaleDeadline,
     TIER_THRESHOLDS: TIER_UNLOCK_THRESHOLDS,
   };

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -69,6 +69,7 @@ export interface ResearchViewItem {
   extraLabel?: string;
   extraSeconds?: number;
   buyToHereTooltip?: string;
+  realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
 }
 
 export const VIEWS = [
@@ -732,7 +733,7 @@ export function useResearchViews() {
         isMaxed: boolean;
         impact: number;
         hpp: number;
-        realisticStats?: { layRate: number; shippingRate: number; elr: number };
+        realisticStats?: { layRate: number; shippingRate: number; elr: number; elrDelta: number };
         showDeadlineWarning: boolean;
       }[];
 

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -61,6 +61,7 @@ export interface ResearchViewItem {
   extraStats?: string;
   extraLabel?: string;
   extraSeconds?: number;
+  buyToHereTooltip?: string;
 }
 
 export const VIEWS = [
@@ -337,18 +338,22 @@ export function useResearchViews() {
             pendingDividerTiers.delete(r.tier);
           }
 
-          const { timeToBuy, secondsToBuy } = formatTimeToBuy(item.price, currentSimSnapshot);
-          totalSeconds += secondsToBuy === Infinity ? 0 : secondsToBuy;
+          const { secondsToBuy: sequentialSecondsToBuy } = formatTimeToBuy(item.price, currentSimSnapshot);
+          totalSeconds += sequentialSecondsToBuy === Infinity ? 0 : sequentialSecondsToBuy;
+
+          const rawSnapshot = { ...currentSimSnapshot, bankValue: 0 };
+          const { timeToBuy: rawTimeToBuy, secondsToBuy: rawSecondsToBuy } = formatTimeToBuy(item.price, rawSnapshot);
 
           result.push({
             research: r,
             targetLevel: item.targetLevel,
             price: item.price,
             currentLevel: researchLevels[r.id] || 0,
-            timeToBuy: timeToBuy,
-            timeToBuySeconds: secondsToBuy,
+            timeToBuy: rawTimeToBuy,
+            timeToBuySeconds: rawSecondsToBuy,
             buyToHereTime: totalSeconds > 0 ? formatDuration(totalSeconds) : '0s',
             buyToHereSeconds: totalSeconds,
+            buyToHereTooltip: totalSeconds < rawSecondsToBuy ? 'Includes existing gems from your bank. Individual research wait times show the time to save from 0.' : undefined,
             canBuy: true,
             isMaxed: false,
             showDivider: item.showDivider || false,
@@ -361,9 +366,9 @@ export function useResearchViews() {
             population: Math.min(
               currentSimSnapshot.habCapacity,
               currentSimSnapshot.population +
-              (currentSimSnapshot.offlineIHR / 60) * (secondsToBuy === Infinity ? 0 : secondsToBuy)
+              (currentSimSnapshot.offlineIHR / 60) * (sequentialSecondsToBuy === Infinity ? 0 : sequentialSecondsToBuy)
             ),
-            bankValue: 0,
+            bankValue: Math.max(0, (currentSimState.bankValue || 0) - item.price),
             researchLevels: {
               ...currentSimState.researchLevels,
               [r.id]: (currentSimState.researchLevels[r.id] || 0) + 1,
@@ -412,18 +417,22 @@ export function useResearchViews() {
         const key = `${r.id}-${item.targetLevel}`;
         if (!processed.has(key)) {
           processed.add(key);
-          const { timeToBuy, secondsToBuy } = formatTimeToBuy(item.price, currentSimSnapshot);
-          totalSeconds += secondsToBuy === Infinity ? 0 : secondsToBuy;
+          const { secondsToBuy: sequentialSecondsToBuy } = formatTimeToBuy(item.price, currentSimSnapshot);
+          totalSeconds += sequentialSecondsToBuy === Infinity ? 0 : sequentialSecondsToBuy;
+
+          const rawSnapshot = { ...currentSimSnapshot, bankValue: 0 };
+          const { timeToBuy: rawTimeToBuy, secondsToBuy: rawSecondsToBuy } = formatTimeToBuy(item.price, rawSnapshot);
 
           result.push({
             research: r,
             targetLevel: item.targetLevel,
             price: item.price,
             currentLevel: researchLevels[r.id] || 0,
-            timeToBuy: timeToBuy,
-            timeToBuySeconds: secondsToBuy,
+            timeToBuy: rawTimeToBuy,
+            timeToBuySeconds: rawSecondsToBuy,
             buyToHereTime: totalSeconds > 0 ? formatDuration(totalSeconds) : '0s',
             buyToHereSeconds: totalSeconds,
+            buyToHereTooltip: totalSeconds < rawSecondsToBuy ? 'Includes existing gems from your bank. Individual research wait times show the time to save from 0.' : undefined,
             canBuy: true,
             isMaxed: false,
             showDeadlineWarning: isSale && (absoluteSimTime + totalSeconds > researchSaleDeadline.value),

--- a/wasmegg/ascension-planner/src/engine/adapter.ts
+++ b/wasmegg/ascension-planner/src/engine/adapter.ts
@@ -94,7 +94,8 @@ export function createBaseEngineState(initialSnapshot?: CalculationsSnapshot | n
     vehicles: [{ vehicleId: 0, trainLength: 1 }], // Default Trike
     habIds: [0, null, null, null], // Default Coop
     researchLevels: {},
-    siloCount: 1,
+    siloCount: silosStore.siloCount || 1,
+    tankLevel: fuelTankStore.tankLevel || 0,
 
     artifactLoadout: initialStateStore.artifactLoadout.map(slot => ({
       artifactId: slot.artifactId,

--- a/wasmegg/ascension-planner/src/engine/adapter.ts
+++ b/wasmegg/ascension-planner/src/engine/adapter.ts
@@ -2,14 +2,9 @@ import type { EngineState, SimulationContext } from './types';
 import type { CalculationsSnapshot } from '@/types';
 import { useInitialStateStore } from '@/stores/initialState';
 import { useVirtueStore } from '@/stores/virtue';
-import { useCommonResearchStore } from '@/stores/commonResearch';
-import { useHabCapacityStore } from '@/stores/habCapacity';
-import { useShippingCapacityStore } from '@/stores/shippingCapacity';
 import { useSilosStore } from '@/stores/silos';
 import { useFuelTankStore } from '@/stores/fuelTank';
-import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useActionsStore } from '@/stores/actions';
-import { createEmptySnapshot } from '@/types';
 import { restoreFromSnapshot } from '@/lib/actions/snapshot';
 import { getLocalTimestampInTimezone } from '@/lib/events';
 
@@ -59,6 +54,7 @@ export function createBaseEngineState(initialSnapshot?: CalculationsSnapshot | n
       habIds: [...initialSnapshot.habIds],
       researchLevels: { ...initialSnapshot.researchLevels },
       siloCount: initialSnapshot.siloCount,
+      tankLevel: initialSnapshot.tankLevel || 0,
       artifactLoadout: initialSnapshot.artifactLoadout.map(slot => ({
         artifactId: slot.artifactId,
         stones: [...slot.stones],
@@ -73,29 +69,18 @@ export function createBaseEngineState(initialSnapshot?: CalculationsSnapshot | n
       bankValue: initialSnapshot.bankValue || 0,
       activeSales: { ...initialSnapshot.activeSales },
       earningsBoost: { ...initialSnapshot.earningsBoost },
-      tankLevel: initialSnapshot.tankLevel || 0,
     };
   }
 
-  // Fallback to reading from InitialStateStore.
-  // IMPORTANT: We do NOT read from the live farm stores (commonResearchStore, etc.)
-  // because those represent the results of the current simulation.
-  // We only use the stores that hold the DEFINITION of the player (InitialStateStore, VirtueStore).
-
-  // We always use empty defaults for the base state.
-  // Farm state (research, habs, vehicles) should only be populated via a
-  // Start Ascension action if the user chooses to "Continue Ascension".
+  // Fallback state
   return {
-    // We always start curiosity by default; start_ascension will override this.
     currentEgg: 'curiosity',
-
     shiftCount: virtueStore.initialShiftCount,
     te: virtueStore.initialTE,
     soulEggs: initialStateStore.soulEggs,
 
-    // Defaults for a new farm
-    vehicles: [{ vehicleId: 0, trainLength: 1 }], // Default Trike
-    habIds: [0, null, null, null], // Default Coop
+    vehicles: [{ vehicleId: 0, trainLength: 1 }], 
+    habIds: [0, null, null, null],
     researchLevels: {},
     siloCount: silosStore.siloCount || 1,
     tankLevel: fuelTankStore.tankLevel || 0,

--- a/wasmegg/ascension-planner/src/engine/adapter.ts
+++ b/wasmegg/ascension-planner/src/engine/adapter.ts
@@ -44,6 +44,8 @@ export function getSimulationContext(): SimulationContext {
 export function createBaseEngineState(initialSnapshot?: CalculationsSnapshot | null): EngineState {
   const virtueStore = useVirtueStore();
   const initialStateStore = useInitialStateStore();
+  const silosStore = useSilosStore();
+  const fuelTankStore = useFuelTankStore();
 
   // If a specific snapshot is provided (e.g. from existing action history), use it.
   // Otherwise, read the current "base" state from the hydrated stores.
@@ -71,6 +73,7 @@ export function createBaseEngineState(initialSnapshot?: CalculationsSnapshot | n
       bankValue: initialSnapshot.bankValue || 0,
       activeSales: { ...initialSnapshot.activeSales },
       earningsBoost: { ...initialSnapshot.earningsBoost },
+      tankLevel: initialSnapshot.tankLevel || 0,
     };
   }
 

--- a/wasmegg/ascension-planner/src/engine/compute.ts
+++ b/wasmegg/ascension-planner/src/engine/compute.ts
@@ -178,6 +178,7 @@ export function computeSnapshot(
     soulEggs: state.soulEggs,
     siloCount: state.siloCount,
     siloTimeMinutes,
+    tankLevel: state.tankLevel,
     fuelTankAmounts: state.fuelTankAmounts,
     eggsDelivered: state.eggsDelivered,
     teEarned: state.teEarned,

--- a/wasmegg/ascension-planner/src/engine/types.ts
+++ b/wasmegg/ascension-planner/src/engine/types.ts
@@ -18,6 +18,7 @@ export interface EngineState {
   vehicles: VehicleSlot[];
   researchLevels: ResearchLevels;
   siloCount: number;
+  tankLevel: number;
 
   // Artifacts
   artifactLoadout: ArtifactSlotPayload[];

--- a/wasmegg/ascension-planner/src/lib/actions/snapshot.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/snapshot.ts
@@ -78,6 +78,7 @@ export function computeCurrentSnapshot(): CalculationsSnapshot {
     siloTimeMinutes,
 
     // Fuel tank state
+    tankLevel: fuelTankStore.tankLevel,
     fuelTankAmounts: { ...fuelTankStore.fuelAmounts },
 
     // Truth Eggs state
@@ -223,6 +224,7 @@ export function restoreFromSnapshot(snapshot: CalculationsSnapshot): void {
   // Restore fuel tank state
   if (snapshot.fuelTankAmounts) {
     fuelTankStore.$patch(state => {
+      state.tankLevel = snapshot.tankLevel ?? state.tankLevel;
       state.fuelAmounts = { ...snapshot.fuelTankAmounts };
     });
   }

--- a/wasmegg/ascension-planner/src/lib/continuity.ts
+++ b/wasmegg/ascension-planner/src/lib/continuity.ts
@@ -16,7 +16,7 @@ export async function checkAndHandleContinuity(
     dependsOn: string[];
   },
   insertIndex: number,
-  removeActionsCallback: (idsToRemove: string[]) => void
+  removeActionsCallback: (idsToRemove: string[]) => Promise<void>
 ): Promise<boolean> {
   // If inserting at end, no future conflicts possible
   // (Unless there's some complex time travel, but usually insertion at end is current)
@@ -133,7 +133,7 @@ export async function checkAndHandleContinuity(
       }
     }
 
-    removeActionsCallback(conflicts.map(a => a.id));
+    await removeActionsCallback(conflicts.map(a => a.id));
     return true;
   } else {
     // User cancelled

--- a/wasmegg/ascension-planner/src/lib/format.ts
+++ b/wasmegg/ascension-planner/src/lib/format.ts
@@ -7,15 +7,62 @@
  * Format a large number with suffixes (K, M, B, T, etc.) or scientific notation.
  *
  * @param value - The number to format
- * @param decimals - Number of decimal places (default: 2)
+ * @param decimals - Number of decimal places (default: 3)
  * @returns Formatted string
  *
  * @example
- * formatNumber(1234) // "1.23K"
- * formatNumber(1234567890) // "1.23B"
- * formatNumber(1e20) // "1.00e+20"
+ * formatNumber(1234) // "1.234K"
+ * formatNumber(1234567890) // "1.235B"
+ * formatNumber(1e20) // "1.000e+20"
  */
-export function formatNumber(value: number, decimals: number = 2): string {
+const SUFFIXES = [
+  '',
+  'K',
+  'M',
+  'B',
+  'T',
+  'q',
+  'Q',
+  's',
+  'S',
+  'o',
+  'N',
+  'd',
+  'U',
+  'D',
+  'Td',
+  'qd',
+  'Qd',
+  'sd',
+  'Sd',
+  'Od',
+  'Nd',
+  'V',
+  'uV',
+  'dV',
+  'tV',
+  'qV',
+  'QV',
+  'sV',
+  'Sv',
+  'OV',
+  'NV',
+  'tT',
+];
+
+/**
+ * Format a large number with suffixes (K, M, B, T, etc.) or scientific notation.
+ *
+ * @param value - The number to format
+ * @param decimals - Number of decimal places (default: 3)
+ * @returns Formatted string
+ *
+ * @example
+ * formatNumber(1234) // "1.234K"
+ * formatNumber(1234567890) // "1.235B"
+ * formatNumber(1e20) // "1.000e+20"
+ */
+export function formatNumber(value: number, decimals: number = 3): string {
   if (value === 0) return '0';
   if (!isFinite(value)) return '∞';
 
@@ -23,47 +70,13 @@ export function formatNumber(value: number, decimals: number = 2): string {
   if (Math.abs(value) < 1000) {
     result = value.toFixed(decimals);
   } else {
-    const suffixes = [
-      '',
-      'K',
-      'M',
-      'B',
-      'T',
-      'q',
-      'Q',
-      's',
-      'S',
-      'o',
-      'N',
-      'd',
-      'U',
-      'D',
-      'Td',
-      'qd',
-      'Qd',
-      'sd',
-      'Sd',
-      'Od',
-      'Nd',
-      'V',
-      'uV',
-      'dV',
-      'tV',
-      'qV',
-      'QV',
-      'sV',
-      'Sv',
-      'OV',
-      'NV',
-      'tT',
-    ];
     const magnitude = Math.floor(Math.log10(Math.abs(value)) / 3);
 
-    if (magnitude >= suffixes.length) {
+    if (magnitude >= SUFFIXES.length) {
       result = value.toExponential(decimals);
     } else {
       const scaled = value / Math.pow(1000, magnitude);
-      result = scaled.toFixed(decimals) + suffixes[magnitude];
+      result = scaled.toFixed(decimals) + SUFFIXES[magnitude];
     }
   }
 
@@ -77,6 +90,23 @@ export function formatNumber(value: number, decimals: number = 2): string {
   }
 
   return result;
+}
+
+/**
+ * Format a value using the same magnitude/suffix as a reference value.
+ * Useful for showing deltas next to a total (e.g. "1.234q (+0.001q)").
+ */
+export function formatWithReference(value: number, reference: number, decimals: number = 3): string {
+  if (value === 0) return '0';
+  if (!isFinite(value)) return '∞';
+
+  // If reference is small or exponential, just use standard formatting
+  if (Math.abs(reference) < 1000) return value.toFixed(decimals);
+  const magnitude = Math.floor(Math.log10(Math.abs(reference)) / 3);
+  if (magnitude >= SUFFIXES.length) return value.toExponential(decimals);
+
+  const scaled = value / Math.pow(1000, magnitude);
+  return scaled.toFixed(decimals) + SUFFIXES[magnitude];
 }
 
 /**

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -683,6 +683,8 @@ export const useActionsStore = defineStore('actions', {
 
       if (!skipRecalculate) {
         await this.recalculateFrom(0);
+      } else {
+        syncStoresToSnapshot(this.effectiveSnapshot);
       }
       this.lastSavedActionsJson = JSON.stringify(this.actions);
       return true;

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -406,7 +406,7 @@ export const useActionsStore = defineStore('actions', {
 
       startAction.payload.initialEgg = egg;
 
-      const keptActions = [startAction];
+      const keptActions: Action[] = [startAction];
       let foundWait = false;
 
       for (let i = 1; i < this.actions.length; i++) {

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -402,9 +402,47 @@ export const useActionsStore = defineStore('actions', {
 
     async setInitialEgg(egg: VirtueEgg) {
       const startAction = this.getStartAction();
-      if (startAction) {
-        startAction.payload.initialEgg = egg;
+      if (!startAction) return;
+
+      startAction.payload.initialEgg = egg;
+
+      const keptActions = [startAction];
+      let foundWait = false;
+
+      for (let i = 1; i < this.actions.length; i++) {
+        const a = this.actions[i];
+        if (a.type === 'wait_for_full_habs' && !foundWait) {
+          keptActions.push(a);
+          foundWait = true;
+        } else if (a.type === 'shift') {
+          // As soon as we see the first shift, we stop considering any waits
+          break;
+        }
       }
+
+      keptActions.forEach((a, idx) => {
+        a.index = idx;
+        a.dependents = [];
+      });
+      
+      for (let i = 1; i < keptActions.length; i++) {
+        keptActions[i].dependsOn = [keptActions[i - 1].id];
+        keptActions[i - 1].dependents.push(keptActions[i].id);
+      }
+
+      this.actions = keptActions;
+
+      const keptIds = new Set(keptActions.map(a => a.id));
+      if (this.editingGroupId && !keptIds.has(this.editingGroupId)) {
+        this.editingGroupId = null;
+      }
+      for (const id of Array.from(this.expandedGroupIds)) {
+        if (!keptIds.has(id)) {
+          this.expandedGroupIds.delete(id);
+        }
+      }
+
+      await this.recalculateFrom(0);
     },
 
     setEditingGroup(groupId: string | null) {

--- a/wasmegg/ascension-planner/src/stores/actions/io.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/io.ts
@@ -9,6 +9,7 @@ import { useVirtueStore } from '@/stores/virtue';
 import { useFuelTankStore } from '@/stores/fuelTank';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useNotesStore } from '@/stores/notes';
+import { useSilosStore } from '@/stores/silos';
 import type { VirtueEgg, Action, CalculationsSnapshot } from '@/types';
 
 export function exportPlanData(actions: Action[], initialSnapshot?: CalculationsSnapshot, activePlanId: string | null = null) {
@@ -18,10 +19,14 @@ export function exportPlanData(actions: Action[], initialSnapshot?: Calculations
   const truthEggsStore = useTruthEggsStore();
   const notesStore = useNotesStore();
 
+  const silosStore = useSilosStore();
+
   const baseSoulEggs = initialSnapshot ? initialSnapshot.soulEggs : initialStateStore.soulEggs;
   const baseLoadout = initialSnapshot ? initialSnapshot.artifactLoadout : initialStateStore.artifactLoadout;
   const baseSets = initialSnapshot ? initialSnapshot.artifactSets : initialStateStore.artifactSets;
   const baseActiveSet = initialSnapshot ? initialSnapshot.activeArtifactSet : initialStateStore.activeArtifactSet;
+  const baseSiloCount = initialSnapshot ? initialSnapshot.siloCount : silosStore.siloCount;
+  const baseTankLevel = initialSnapshot ? (initialSnapshot.tankLevel ?? fuelTankStore.tankLevel) : fuelTankStore.tankLevel;
   const baseFuelAmounts = initialSnapshot ? initialSnapshot.fuelTankAmounts : fuelTankStore.fuelAmounts;
   const baseEggsDelivered = initialSnapshot ? initialSnapshot.eggsDelivered : truthEggsStore.eggsDelivered;
   const baseTeEarned = initialSnapshot ? initialSnapshot.teEarned : truthEggsStore.teEarned;
@@ -41,9 +46,11 @@ export function exportPlanData(actions: Action[], initialSnapshot?: Calculations
       activeArtifactSet: baseActiveSet,
       currentFarmState: initialStateStore.currentFarmState,
       assumeDoubleEarnings: initialStateStore.assumeDoubleEarnings,
-      initialFuelAmounts: initialStateStore.initialFuelAmounts,
-      initialEggsDelivered: initialStateStore.initialEggsDelivered,
-      initialTeEarned: initialStateStore.initialTeEarned,
+      initialSiloCount: baseSiloCount,
+      initialTankLevel: baseTankLevel,
+      initialFuelAmounts: baseFuelAmounts,
+      initialEggsDelivered: baseEggsDelivered,
+      initialTeEarned: baseTeEarned,
     },
     virtueState: {
       shiftCount: virtueStore.initialShiftCount,
@@ -53,7 +60,7 @@ export function exportPlanData(actions: Action[], initialSnapshot?: Calculations
       ascensionTimezone: virtueStore.ascensionTimezone,
     },
     fuelTankState: {
-      tankLevel: fuelTankStore.tankLevel,
+      tankLevel: baseTankLevel,
       fuelAmounts: baseFuelAmounts,
     },
     truthEggsState: {

--- a/wasmegg/ascension-planner/src/stores/initialState.ts
+++ b/wasmegg/ascension-planner/src/stores/initialState.ts
@@ -27,6 +27,7 @@ import {
 } from '@/lib/artifacts';
 import { countTEThresholdsPassed } from '@/lib/truthEggs';
 import { useTruthEggsStore, VIRTUE_TE_ORDER } from './truthEggs';
+import { useFuelTankStore } from './fuelTank';
 
 export interface InitialStateStoreState {
   // Whether data has been loaded from a backup

--- a/wasmegg/ascension-planner/src/stores/initialState.ts
+++ b/wasmegg/ascension-planner/src/stores/initialState.ts
@@ -59,6 +59,7 @@ export interface InitialStateStoreState {
   assumeDoubleEarnings: boolean;
 
   // Global progress metrics at start of ascension
+  initialTankLevel: number;
   initialFuelAmounts: Record<VirtueEgg, number>;
   initialEggsDelivered: Record<VirtueEgg, number>;
   initialTeEarned: Record<VirtueEgg, number>;
@@ -107,6 +108,7 @@ export const useInitialStateStore = defineStore('initialState', {
     currentFarmState: null,
     soulEggs: 1e21, // Default to 1s
     assumeDoubleEarnings: true,
+    initialTankLevel: 0,
     initialFuelAmounts: createEmptyVirtueMap(),
     initialEggsDelivered: createEmptyVirtueMap(),
     initialTeEarned: createEmptyVirtueMap(),
@@ -280,6 +282,7 @@ export const useInitialStateStore = defineStore('initialState', {
         resilience: tankFuels[23] ?? 0,
         kindness: tankFuels[24] ?? 0,
       };
+      this.initialTankLevel = tankLevel;
       this.initialFuelAmounts = { ...virtueFuelAmounts };
       this.initialEggsDelivered = { ...eggsDelivered };
       this.initialTeEarned = { ...teEarnedPerEgg };
@@ -485,7 +488,9 @@ export const useInitialStateStore = defineStore('initialState', {
         this.assumeDoubleEarnings = true;
       }
       this.currentFarmState = data.currentFarmState || null;
-
+      if (data.initialTankLevel !== undefined) {
+        this.initialTankLevel = data.initialTankLevel;
+      }
       if (data.initialFuelAmounts) {
         this.initialFuelAmounts = { ...data.initialFuelAmounts };
       }
@@ -502,10 +507,15 @@ export const useInitialStateStore = defineStore('initialState', {
         this.activeMissions = [...data.activeMissions];
       }
 
-      // Sync Truth Eggs Store if handled here
+      // Sync Truth Eggs Store
       const truthEggsStore = useTruthEggsStore();
       truthEggsStore.eggsDelivered = { ...this.initialEggsDelivered };
       truthEggsStore.teEarned = { ...this.initialTeEarned };
+
+      // Sync Fuel Tank Store
+      const fuelTankStore = useFuelTankStore();
+      fuelTankStore.tankLevel = this.initialTankLevel;
+      fuelTankStore.fuelAmounts = { ...this.initialFuelAmounts };
     },
 
     /**
@@ -552,6 +562,7 @@ export const useInitialStateStore = defineStore('initialState', {
       this.activeArtifactSet = null;
       this.soulEggs = 1e21;
       this.assumeDoubleEarnings = true;
+      this.initialTankLevel = 0;
       this.initialFuelAmounts = createEmptyVirtueMap();
       this.initialEggsDelivered = createEmptyVirtueMap();
       this.initialTeEarned = createEmptyVirtueMap();

--- a/wasmegg/ascension-planner/src/types/actions/core.ts
+++ b/wasmegg/ascension-planner/src/types/actions/core.ts
@@ -129,6 +129,7 @@ export interface CalculationsSnapshot {
   soulEggs: number;
   siloCount: number;
   siloTimeMinutes: number;
+  tankLevel: number;
   fuelTankAmounts: Record<VirtueEgg, number>;
   eggsDelivered: Record<VirtueEgg, number>;
   teEarned: Record<VirtueEgg, number>;

--- a/wasmegg/ascension-planner/src/types/actions/meta.ts
+++ b/wasmegg/ascension-planner/src/types/actions/meta.ts
@@ -164,6 +164,7 @@ export function createEmptySnapshot(): CalculationsSnapshot {
     soulEggs: 0,
     siloCount: 1,
     siloTimeMinutes: 60,
+    tankLevel: 0,
     fuelTankAmounts: {
       curiosity: 0,
       integrity: 0,


### PR DESCRIPTION
### Updates
* ELR View for research allows you to view by realistic improvements (assuming max vehicles, habs, and optimal artifacts) or by potential theoretical gain
* ELR View for research allows sort by total gains or by efficiency (gains per hour of earnings)
* Notes auto-hide
* Smart Buy won't spend gems from your bank
### Bug Fixes
* Moving research between shifts no longer breaks research purchased
* Cheapest first purchases now factor in your bank savings
* Changing initial egg now wipes your plan
* Refreshing the page correctly retains purchased research
* Catch-up earnings doesn't double count on Continue Ascension
* ELR Impact price now ignores your bank when calculating how long it takes to save
* Reopening a saved plan correctly populates fuel tank levels