### PR TITLE
Add Bulk Wait for TE feature

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -728,14 +728,9 @@ async function startFromScratch() {
   await actionsStore.clearAll();
 
   // 2. Reset all definition stores to their default/clean states.
-  // We do this AFTER clearAll because clearAll's simulation sync
-  // would otherwise overwrite these stores with old snapshot data.
-  const cachedBackup = initialStateStore.rawBackup;
-  const cachedPlayerId = initialStateStore.playerId;
   initialStateStore.$reset();
-  if (cachedPlayerId && cachedBackup) {
-    initialStateStore.loadFromBackup(cachedPlayerId, cachedBackup, 'scratch');
-  }
+
+  // 3. Reset all other stores to their default/clean states
   virtueStore.$reset();
   fuelTankStore.$reset();
   truthEggsStore.$reset();
@@ -807,7 +802,19 @@ async function handleRefreshReconcile() {
     await saveMetadata(pHash, 'rawBackup', backup);
     
     // Load into state store
-    initialStateStore.loadFromBackup(playerId.value, backup, 'reconcile');
+    const { 
+      initialShiftCount, 
+      initialTE, 
+      tankLevel, 
+      virtueFuelAmounts,
+    } = initialStateStore.loadFromBackup(playerId.value, backup, 'reconcile');
+
+    // Sync stores
+    virtueStore.setInitialState(initialShiftCount, initialTE);
+    fuelTankStore.setTankLevel(tankLevel);
+    for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
+      fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
+    }
     
     // Update reconciliation targets in actionsStore
     if (initialStateStore.currentFarmState) {
@@ -870,13 +877,6 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
       teEarnedPerEgg 
     } = initialStateStore.loadFromBackup(id, backup, mode);
 
-    // Catch-up calculations (eggs, earnings, population) are now handled 
-    // automatically by computeSnapshot in the engine. We compute the initial 
-    // snapshot first and then sync the results back to the stores.
-    const context = getSimulationContext();
-    const baseState = createBaseEngineState(null);
-    const initialSnapshot = computeSnapshot(baseState, context);
-
     // Initialize virtue store with player's shift count and TE
     virtueStore.setInitialState(initialShiftCount, initialTE);
 
@@ -885,6 +885,13 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
     for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
       fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
     }
+
+    // Catch-up calculations (eggs, earnings, population) are now handled 
+    // automatically by computeSnapshot in the engine. We compute the initial 
+    // snapshot first and then sync the results back to the stores.
+    const context = getSimulationContext();
+    const baseState = createBaseEngineState(null);
+    const initialSnapshot = computeSnapshot(baseState, context);
 
     // Initialize truth eggs store with caught-up data from snapshot
     for (const [egg, amount] of Object.entries(initialSnapshot.eggsDelivered)) {
@@ -918,9 +925,8 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
       initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - earned));
     }
 
-    if (mode !== 'plan_next') {
-      await actionsStore.setInitialSnapshot(initialSnapshot);
-    }
+    // Initialize initial state in actions store
+    await actionsStore.setInitialSnapshot(initialSnapshot);
 
     loading.value = false;
   } catch (e) {

--- a/wasmegg/ascension-planner/src/components/EventExpiryDialog.vue
+++ b/wasmegg/ascension-planner/src/components/EventExpiryDialog.vue
@@ -102,8 +102,10 @@ function formatTime(timestamp: number): string {
 function formatDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
   if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
 }
 </script>
 

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -268,7 +268,7 @@ const eggPlans = computed(() => {
   const fullHabRate = Math.min(S, R * H);
   
   let runningTimeSeconds = 0;
-  const planStartOffset = (actionsStore as any).planStartOffset || 0;
+  const planStartOffset = actionsStore.planStartOffset || 0;
   const baseTime = snapshot.lastStepTime;
 
   return visitOrder.value.map((egg, index) => {
@@ -388,7 +388,7 @@ function adjustEgg(egg: VirtueEgg, delta: number) {
   });
 
   // Update total based on new sum
-  totalTEToGain.value = Object.values(manualGains.value).reduce((sum, v) => sum + (v || 0), 0);
+  totalTEToGain.value = Object.values(manualGains.value).reduce<number>((sum, v) => (sum || 0) + (v || 0), 0);
 }
 
 function rebalance() {

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -1,0 +1,527 @@
+<template>
+  <div class="space-y-6">
+    <!-- Header: Total Gain and Final TE -->
+    <div class="bg-slate-50/50 rounded-xl p-4 border border-slate-100 flex flex-wrap items-center justify-between gap-4">
+      <div class="space-y-1">
+        <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Total TE to Gain</label>
+        <div class="flex items-center gap-3">
+          <button 
+            class="w-8 h-8 rounded-lg bg-white border border-slate-200 flex items-center justify-center text-slate-500 hover:bg-slate-50 active:scale-95 transition-all shadow-sm"
+            @click="adjustTotal(-1)"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" /></svg>
+          </button>
+          <input 
+            type="number"
+            v-model.number="totalTEToGain"
+            class="w-16 bg-white border border-slate-200 rounded-lg px-2 py-1 text-center font-mono-premium font-bold text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900/5 transition-all shadow-sm"
+            @change="handleTotalChange"
+          />
+          <button 
+            class="w-8 h-8 rounded-lg bg-white border border-slate-200 flex items-center justify-center text-slate-500 hover:bg-slate-50 active:scale-95 transition-all shadow-sm"
+            @click="adjustTotal(1)"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400 text-right">Final Total TE</label>
+        <div class="flex items-center justify-end gap-2">
+          <span class="font-mono-premium font-black text-2xl text-slate-900">{{ finalTotalTE }}</span>
+          <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-6 h-6 object-contain" />
+        </div>
+      </div>
+
+      <div class="w-full sm:w-auto">
+        <button 
+          class="w-full sm:w-auto px-4 py-2 rounded-lg font-black text-[10px] uppercase tracking-wider transition-all shadow-sm border"
+          :class="canRebalance ? 'bg-slate-900 text-white border-slate-900 hover:bg-slate-800' : 'bg-white text-slate-300 border-slate-100 cursor-not-allowed'"
+          :disabled="!canRebalance"
+          @click="rebalance"
+        >
+          Rebalance
+        </button>
+      </div>
+    </div>
+
+    <!-- Egg Visit Order -->
+    <div class="space-y-3">
+      <div 
+        v-for="(eggPlan, index) in eggPlans" 
+        :key="eggPlan.egg"
+        class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden"
+        :class="{ 'ring-1 ring-slate-900/5': eggPlan.isCurrentEgg }"
+      >
+        <div class="px-5 py-4 flex items-center justify-between gap-4">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-xl bg-slate-50 border border-slate-100 flex items-center justify-center p-1.5 shadow-inner">
+              <img :src="iconURL(`egginc/egg_${eggPlan.egg}.png`, 64)" class="w-full h-full object-contain" />
+            </div>
+            <div>
+              <div class="flex items-center gap-2">
+                <span class="font-black text-[10px] uppercase text-slate-900">{{ VIRTUE_EGG_NAMES[eggPlan.egg] }}</span>
+                <span class="text-slate-600 text-[10px] font-bold">{{ formatDuration(eggPlan.durationSeconds) }}</span>
+                <span v-if="eggPlan.isCurrentEgg" class="px-1.5 py-0.5 bg-slate-900 text-white text-[8px] font-black uppercase tracking-tighter rounded">Current</span>
+              </div>
+              <div class="text-[10px] font-mono-premium text-slate-400 mt-0.5">
+                <span v-if="index === eggPlans.length - 1">Prestige on</span>
+                <span v-else>Shift on</span>
+                <span class="text-slate-500">&nbsp;{{ eggPlan.absoluteTime }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <!-- Individual Adjustments -->
+            <div class="flex items-center bg-slate-50 rounded-lg border border-slate-100 p-0.5 shadow-inner">
+              <button 
+                class="w-6 h-6 rounded flex items-center justify-center text-slate-400 hover:text-slate-900 hover:bg-white transition-all active:scale-90"
+                @click="adjustEgg(eggPlan.egg, -1)"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" /></svg>
+              </button>
+              <span class="px-2 text-center text-xs font-mono-premium font-black text-slate-900">
+                {{ eggPlan.targetTE }}
+                <span class="text-indigo-600 font-bold ml-1">(+{{ eggPlan.teToGain }})</span>
+              </span>
+              <button 
+                class="w-6 h-6 rounded flex items-center justify-center text-slate-400 hover:text-slate-900 hover:bg-white transition-all active:scale-90"
+                @click="adjustEgg(eggPlan.egg, 1)"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+              </button>
+            </div>
+
+            <!-- Reorder Controls -->
+            <div v-if="!eggPlan.isCurrentEgg" class="flex flex-col gap-0.5">
+              <button 
+                class="w-6 h-5 flex items-center justify-center text-slate-300 hover:text-slate-900 transition-all"
+                :class="{ 'opacity-0 pointer-events-none': index === 1 }"
+                @click="moveEgg(index, -1)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" /></svg>
+              </button>
+              <button 
+                class="w-6 h-5 flex items-center justify-center text-slate-300 hover:text-slate-900 transition-all"
+                :class="{ 'opacity-0 pointer-events-none': index === eggPlans.length - 1 }"
+                @click="moveEgg(index, 1)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Summary -->
+    <div v-if="totalTEToGain > 0" class="bg-slate-900 rounded-2xl p-5 text-white shadow-xl shadow-slate-900/20">
+      <div class="flex items-center justify-between">
+        <div class="space-y-1">
+          <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Total Duration</label>
+          <div class="text-xl font-mono-premium font-black">{{ formatDuration(totalDurationSeconds) }}</div>
+        </div>
+        <div class="text-right space-y-1">
+          <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Final Completion</label>
+          <div class="text-sm font-bold text-slate-200 italic">{{ finalAbsoluteTime }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Apply Button -->
+    <div class="pt-2">
+      <button 
+        class="btn-premium btn-primary w-full py-4 text-xs font-black uppercase tracking-[0.3em] shadow-xl"
+        :disabled="totalTEToGain <= 0"
+        @click="handleApply"
+      >
+        Apply Bulk TE Plan
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { iconURL, shiftCost } from 'lib';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useVirtueStore } from '@/stores/virtue';
+import { useActionsStore } from '@/stores/actions';
+import { useActionExecutor } from '@/composables/useActionExecutor';
+import { computeDependencies } from '@/lib/actions/executor';
+import { formatNumber, formatDuration, formatAbsoluteTime } from '@/lib/format';
+import { generateActionId, VIRTUE_EGG_NAMES, VIRTUE_EGGS, type VirtueEgg } from '@/types';
+import { TE_BREAKPOINTS, countTEThresholdsPassed, MAX_TE, eggsNeededForTE } from '@/lib/truthEggs';
+import { integrateRate } from '@/engine/apply/math';
+
+const truthEggsStore = useTruthEggsStore();
+const virtueStore = useVirtueStore();
+const actionsStore = useActionsStore();
+
+const totalTEToGain = ref(15);
+const visitOrder = ref<VirtueEgg[]>([]);
+
+// Per-egg gain overrides (to support manual adjustments)
+const manualGains = ref<Record<VirtueEgg, number | null>>({
+  curiosity: null,
+  integrity: null,
+  humility: null,
+  resilience: null,
+  kindness: null,
+});
+
+// Current starting stats per egg (accounts for pending TE in the plan)
+const eggStartStates = computed(() => {
+  const stats: Record<VirtueEgg, { te: number; delivered: number }> = {} as any;
+  const snapshot = actionsStore.effectiveSnapshot;
+  
+  for (const egg of VIRTUE_EGGS) {
+    const delivered = snapshot.eggsDelivered[egg] || 0;
+    const earned = snapshot.teEarned?.[egg] || 0;
+    const thresholds = countTEThresholdsPassed(delivered);
+    stats[egg] = {
+      te: Math.max(earned, thresholds),
+      delivered: delivered,
+    };
+  }
+  return stats;
+});
+
+const currentTotalTE = computed(() => {
+  return Object.values(eggStartStates.value).reduce((sum, s) => sum + s.te, 0);
+});
+
+const finalTotalTE = computed(() => currentTotalTE.value + totalTEToGain.value);
+
+/**
+ * The Greedy Allocation Algorithm
+ */
+function calculateGreedyGains(total: number) {
+  const gains: Record<VirtueEgg, number> = {} as any;
+  VIRTUE_EGGS.forEach(e => gains[e] = 0);
+
+  const working = VIRTUE_EGGS.map(egg => ({
+    egg,
+    currentTE: eggStartStates.value[egg].te,
+    currentDelivered: eggStartStates.value[egg].delivered,
+  }));
+
+  for (let i = 0; i < total; i++) {
+    let bestEgg: VirtueEgg | null = null;
+    let bestCost = Infinity;
+
+    for (const w of working) {
+      if (w.currentTE >= MAX_TE) continue;
+
+      const nextThreshold = TE_BREAKPOINTS[w.currentTE];
+      const cost = Math.max(0, nextThreshold - w.currentDelivered);
+
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestEgg = w.egg;
+      }
+    }
+
+    if (!bestEgg) break;
+
+    gains[bestEgg]++;
+    const wEgg = working.find(w => w.egg === bestEgg)!;
+    wEgg.currentTE++;
+    wEgg.currentDelivered = TE_BREAKPOINTS[wEgg.currentTE - 1];
+  }
+
+  return gains;
+}
+
+// Current distribution based on greedy logic or manual overrides
+const distributedGains = computed(() => {
+  // If we have manual overrides that sum to the total, use them.
+  // Otherwise, fallback to greedy for the remaining.
+  // Actually, for simplicity in Phase 1: if ANY are manual, use manual. 
+  // But the plan says Rebalance button resets everything to greedy.
+  
+  const anyManual = Object.values(manualGains.value).some(v => v !== null);
+  if (anyManual) {
+    const gains: Record<VirtueEgg, number> = {} as any;
+    VIRTUE_EGGS.forEach(e => gains[e] = manualGains.value[e] ?? 0);
+    return gains;
+  }
+  
+  return calculateGreedyGains(totalTEToGain.value);
+});
+
+const canRebalance = computed(() => {
+  const greedy = calculateGreedyGains(totalTEToGain.value);
+  return VIRTUE_EGGS.some(e => distributedGains.value[e] !== greedy[e]);
+});
+
+const eggPlans = computed(() => {
+  const currentEgg = actionsStore.effectiveSnapshot.currentEgg as VirtueEgg;
+  const snapshot = actionsStore.effectiveSnapshot;
+  
+  const IHR = snapshot.offlineIHR / 60;
+  const R = snapshot.ratePerChickenPerSecond;
+  const S = snapshot.shippingCapacity;
+  const H = snapshot.habCapacity;
+  const fullHabRate = Math.min(S, R * H);
+  
+  let runningTimeSeconds = 0;
+  const planStartOffset = (actionsStore as any).planStartOffset || 0;
+  const baseTime = snapshot.lastStepTime;
+
+  return visitOrder.value.map((egg, index) => {
+    const start = eggStartStates.value[egg];
+    const gain = distributedGains.value[egg];
+    
+    let durationSeconds = 0;
+    
+    if (gain > 0) {
+      const eggsToLay = eggsNeededForTE(start.delivered, start.te + gain);
+      let currentPop = egg === currentEgg ? snapshot.population : 1;
+      
+      // 1. Hab fill phase
+      if (currentPop < H) {
+        const fillTime = IHR > 0 ? (H - currentPop) / IHR : 0;
+        durationSeconds += fillTime;
+        
+        const eggsDuringFill = integrateRate(fillTime, currentPop, IHR, R, S, H);
+        const remainingToLay = Math.max(0, eggsToLay - eggsDuringFill);
+        
+        // 2. Shipping phase at full capacity
+        durationSeconds += fullHabRate > 0 ? remainingToLay / fullHabRate : 0;
+      } else {
+        durationSeconds += fullHabRate > 0 ? eggsToLay / fullHabRate : 0;
+      }
+    }
+
+    const completionTime = baseTime + runningTimeSeconds + durationSeconds;
+    
+    const plan = {
+      egg,
+      isCurrentEgg: egg === currentEgg,
+      currentTE: start.te,
+      targetTE: start.te + gain,
+      teToGain: gain,
+      durationSeconds,
+      displayTime: formatSimTime(baseTime + runningTimeSeconds),
+      absoluteTime: formatAbsoluteTime(completionTime - planStartOffset, actionsStore.ascensionStartTime),
+    };
+
+    runningTimeSeconds += durationSeconds;
+    return plan;
+  });
+});
+
+const totalDurationSeconds = computed(() => {
+  return eggPlans.value.reduce((sum, p) => sum + p.durationSeconds, 0);
+});
+
+const finalAbsoluteTime = computed(() => {
+  const lastPlan = eggPlans.value[eggPlans.value.length - 1];
+  return lastPlan?.absoluteTime || '---';
+});
+
+/**
+ * Format relative simulation time: "Day X, H:MM AM/PM"
+ */
+function formatSimTime(seconds: number) {
+  // Use current time as fallback for Continue Ascension if store start time is missing
+  const startTime = actionsStore.ascensionStartTime || (Date.now() / 1000);
+  
+  if (isNaN(seconds) || seconds === 0) return 'Day 1, 12:00 AM';
+
+  const relativeSeconds = Math.max(0, seconds - startTime);
+  const day = Math.floor(relativeSeconds / 86400) + 1;
+  const hour = Math.floor((relativeSeconds % 86400) / 3600);
+  const minute = Math.floor((relativeSeconds % 3600) / 60);
+  
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour % 12 || 12;
+  const displayMinute = minute.toString().padStart(2, '0');
+  
+  return `Day ${day}, ${displayHour}:${displayMinute} ${period}`;
+}
+
+// Initialization
+onMounted(() => {
+  const currentEgg = actionsStore.effectiveSnapshot.currentEgg as VirtueEgg;
+  // Current egg first, then others in standard order
+  visitOrder.value = [
+    currentEgg,
+    ...VIRTUE_EGGS.filter(e => e !== currentEgg)
+  ];
+});
+
+// Methods
+function adjustTotal(delta: number) {
+  const newTotal = Math.max(0, totalTEToGain.value + delta);
+  const maxPossibleGain = Object.values(eggStartStates.value).reduce((sum, s) => sum + (MAX_TE - s.te), 0);
+  totalTEToGain.value = Math.min(newTotal, maxPossibleGain);
+  rebalance();
+}
+
+function handleTotalChange() {
+  const maxPossibleGain = Object.values(eggStartStates.value).reduce((sum, s) => sum + (MAX_TE - s.te), 0);
+  totalTEToGain.value = Math.min(Math.max(0, totalTEToGain.value), maxPossibleGain);
+  rebalance();
+}
+
+function adjustEgg(egg: VirtueEgg, delta: number) {
+  // Capture current state before we start modifying dependencies
+  const currentDist = { ...distributedGains.value };
+  const start = eggStartStates.value[egg];
+  const currentGain = currentDist[egg];
+  const newGain = Math.max(0, Math.min(MAX_TE - start.te, currentGain + delta));
+  
+  if (newGain === currentGain) return;
+
+  // Set the manual value for the adjusted egg
+  manualGains.value[egg] = newGain;
+  
+  // Freeze all other eggs to their current values to enter "manual mode" cleanly
+  VIRTUE_EGGS.forEach(e => {
+    if (e !== egg && manualGains.value[e] === null) {
+      manualGains.value[e] = currentDist[e];
+    }
+  });
+
+  // Update total based on new sum
+  totalTEToGain.value = Object.values(manualGains.value).reduce((sum, v) => sum + (v || 0), 0);
+}
+
+function rebalance() {
+  VIRTUE_EGGS.forEach(e => manualGains.value[e] = null);
+}
+
+function moveEgg(index: number, delta: number) {
+  const newIndex = index + delta;
+  if (newIndex < 1 || newIndex >= visitOrder.value.length || index < 1) return;
+  
+  const arr = [...visitOrder.value];
+  const temp = arr[index];
+  arr[index] = arr[newIndex];
+  arr[newIndex] = temp;
+  visitOrder.value = arr;
+}
+
+/**
+ * PHASE 4: Apply Workflow
+ * Generates all actions in a single batch.
+ */
+async function handleApply() {
+  const execute = async (action: any) => {
+    if (actionsStore.editingGroupId) {
+      await actionsStore.insertAction(action);
+    } else {
+      actionsStore.pushAction(action);
+    }
+  };
+
+  actionsStore.startBatch();
+  
+  try {
+    for (const plan of eggPlans.value) {
+      if (plan.teToGain <= 0) continue;
+
+      // 1. If not current egg, we need to SHIFT first
+      if (!plan.isCurrentEgg) {
+        const snapshot = actionsStore.effectiveSnapshot;
+        const fromEgg = snapshot.currentEgg;
+        const toEgg = plan.egg;
+        const newShiftCount = snapshot.shiftCount + 1;
+        const cost = shiftCost(snapshot.soulEggs, snapshot.shiftCount);
+
+        const payload = { fromEgg, toEgg, newShiftCount };
+        await execute({
+          id: generateActionId(),
+          timestamp: Date.now(),
+          type: 'shift' as const,
+          payload,
+          cost,
+          dependsOn: computeDependencies(
+            'shift',
+            payload,
+            actionsStore.actionsBeforeInsertion,
+            actionsStore.initialSnapshot.researchLevels
+          ),
+        });
+        
+        // Use the newly shifted egg for events
+        actionsStore.pushRelevantEvents(toEgg);
+      }
+
+      // 2. Wait for Full Habs
+      {
+        const snapshot = actionsStore.effectiveSnapshot;
+        if (snapshot.population < snapshot.habCapacity) {
+          const IHR = snapshot.offlineIHR / 60;
+          const chickensNeeded = Math.max(0, snapshot.habCapacity - snapshot.population);
+          const totalTimeSeconds = IHR > 0 ? chickensNeeded / IHR : 0;
+
+          const payload = {
+            habCapacity: snapshot.habCapacity,
+            ihr: snapshot.offlineIHR,
+            currentPopulation: snapshot.population,
+            totalTimeSeconds,
+          };
+
+          await execute({
+            id: generateActionId(),
+            timestamp: Date.now(),
+            type: 'wait_for_full_habs' as const,
+            payload,
+            cost: 0,
+            dependsOn: computeDependencies(
+              'wait_for_full_habs',
+              payload,
+              actionsStore.actionsBeforeInsertion,
+              actionsStore.initialSnapshot.researchLevels
+            ),
+          });
+        }
+      }
+
+      // 3. Wait for TE
+      {
+        const snapshot = actionsStore.effectiveSnapshot;
+        const egg = snapshot.currentEgg as VirtueEgg;
+        const eggsToLay = eggsNeededForTE(snapshot.eggsDelivered[egg], plan.targetTE);
+        
+        const payload = {
+          egg,
+          targetTE: plan.targetTE,
+          teGained: plan.teToGain,
+          eggsToLay,
+          timeSeconds: plan.durationSeconds,
+          startEggsDelivered: snapshot.eggsDelivered[egg] || 0,
+          startTE: plan.currentTE,
+        };
+
+        await execute({
+          id: generateActionId(),
+          timestamp: Date.now(),
+          type: 'wait_for_te' as const,
+          payload,
+          cost: 0,
+          dependsOn: computeDependencies(
+            'wait_for_te',
+            payload,
+            actionsStore.actionsBeforeInsertion,
+            actionsStore.initialSnapshot.researchLevels
+          ),
+        });
+      }
+    }
+  } finally {
+    await actionsStore.commitBatch();
+  }
+}
+</script>
+
+<style scoped>
+.font-mono-premium {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -241,7 +241,6 @@ const distributedGains = computed(() => {
   // Otherwise, fallback to greedy for the remaining.
   // Actually, for simplicity in Phase 1: if ANY are manual, use manual. 
   // But the plan says Rebalance button resets everything to greedy.
-  
   const anyManual = Object.values(manualGains.value).some(v => v !== null);
   if (anyManual) {
     const gains: Record<VirtueEgg, number> = {} as any;

--- a/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
@@ -34,6 +34,38 @@
       </div>
     </div>
 
+    <!-- Bulk Wait for TE Section -->
+    <div
+      class="bg-white rounded-2xl border border-slate-100 overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md"
+    >
+      <button
+        class="w-full px-5 py-4 bg-slate-50/50 flex justify-between items-center hover:bg-white transition-colors group"
+        @click="bulkTEExpanded = !bulkTEExpanded"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="w-8 h-8 rounded-xl bg-white border border-slate-200/50 shadow-sm flex items-center justify-center p-1.5 group-hover:scale-110 transition-transform"
+          >
+            <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-full h-full object-contain" />
+          </div>
+          <h3 class="font-black text-[10px] uppercase tracking-[0.2em] text-slate-500">Bulk Wait for TE</h3>
+        </div>
+        <svg
+          class="w-5 h-5 text-slate-300 transition-transform duration-300"
+          :class="{ 'rotate-180 text-slate-900': bulkTEExpanded }"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div v-show="bulkTEExpanded" class="p-6 border-t border-slate-50">
+        <BulkWaitForTEActions />
+      </div>
+    </div>
+
+
     <!-- Wait for Full Habs Section -->
     <div
       class="bg-white rounded-2xl border border-slate-100 overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md"
@@ -235,6 +267,7 @@ import { ref, computed } from 'vue';
 import { iconURL } from 'lib';
 import { useActionsStore } from '@/stores/actions';
 import WaitForTEActions from './WaitForTEActions.vue';
+import BulkWaitForTEActions from './BulkWaitForTEActions.vue';
 import WaitForMissionsActions from './WaitForMissionsActions.vue';
 import WaitForTimeActions from './WaitForTimeActions.vue';
 import WaitForFullHabsActions from './WaitForFullHabsActions.vue';
@@ -248,6 +281,7 @@ const isHumility = computed(() => actionsStore.effectiveSnapshot.currentEgg === 
 const isCuriosity = computed(() => actionsStore.effectiveSnapshot.currentEgg === 'curiosity');
 
 const teExpanded = ref(false);
+const bulkTEExpanded = ref(false);
 const habsExpanded = ref(false);
 const missionsExpanded = ref(false);
 const gemsExpanded = ref(false);

--- a/wasmegg/ascension-planner/src/lib/actions/eventThresholds.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/eventThresholds.ts
@@ -73,10 +73,9 @@ export function checkEventCrossing(
     const completionTimeAbs = planStartTimeSecs + (completionTimeSim - planStartOffset);
 
     return {
-        // We warn if it completes after the threshold. 
-        // We no longer strictly check if currentSimTime < endTimeSim to handle cases 
-        // where the user is already slightly past the threshold but the event is still toggled on.
-        isCrossed: completionTimeSim > endTimeSim,
+        // We warn if it completes at least 1 second after the threshold. 
+        // This avoids nuisance warnings for sub-second overlaps.
+        isCrossed: completionTimeSim >= endTimeSim + 1,
         endTime: endTimeAbs,
         completionTime: completionTimeAbs,
     };

--- a/wasmegg/ascension-planner/src/lib/actions/executor.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/executor.ts
@@ -161,10 +161,14 @@ export function getExecutor<T extends ActionType>(type: T): ActionExecutor<T> {
 export function computeDependencies(
   type: ActionType,
   payload: ActionPayloadMap[ActionType],
-  existingActions: Action[],
+  existingActions: Action[] = [],
   initialResearchLevels: Record<string, number> = {}
 ): string[] {
   const deps: string[] = [];
+
+  if (!existingActions || !Array.isArray(existingActions)) {
+    return [];
+  }
 
   // 1. Every action depends on the most recent shift/start_ascension (the "group header")
   // This ensures that undoing a shift also undoes all actions performed during that shift.

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -113,6 +113,11 @@ export const useActionsStore = defineStore('actions', {
       return startAction.endState.lastStepTime || 0;
     },
 
+    ascensionStartTime(): number {
+      const vStore = useVirtueStore();
+      return vStore.planStartTime.getTime() / 1000;
+    },
+
     getActionReconciliationStatus() {
       return (action: Action): 'completed' | 'pending' | 'na' => {
         if (!this.isReconciling) return 'na';


### PR DESCRIPTION
This adds a new Wait action to allow a user to plan out the end of their ascension quickly and easily, in a single step.

Minor Fixes:
* Fuel Tank Level wasn't pulling from user data
* Event expiration warnings now allow an overlap of 1 second. They were triggering for a few milliseconds of overlap.