### PR TITLE
Add Bulk Wait for TE Feature

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -728,14 +728,9 @@ async function startFromScratch() {
   await actionsStore.clearAll();
 
   // 2. Reset all definition stores to their default/clean states.
-  // We do this AFTER clearAll because clearAll's simulation sync
-  // would otherwise overwrite these stores with old snapshot data.
-  const cachedBackup = initialStateStore.rawBackup;
-  const cachedPlayerId = initialStateStore.playerId;
   initialStateStore.$reset();
-  if (cachedPlayerId && cachedBackup) {
-    initialStateStore.loadFromBackup(cachedPlayerId, cachedBackup, 'scratch');
-  }
+
+  // 3. Reset all other stores to their default/clean states
   virtueStore.$reset();
   fuelTankStore.$reset();
   truthEggsStore.$reset();
@@ -807,7 +802,19 @@ async function handleRefreshReconcile() {
     await saveMetadata(pHash, 'rawBackup', backup);
     
     // Load into state store
-    initialStateStore.loadFromBackup(playerId.value, backup, 'reconcile');
+    const { 
+      initialShiftCount, 
+      initialTE, 
+      tankLevel, 
+      virtueFuelAmounts,
+    } = initialStateStore.loadFromBackup(playerId.value, backup, 'reconcile');
+
+    // Sync stores
+    virtueStore.setInitialState(initialShiftCount, initialTE);
+    fuelTankStore.setTankLevel(tankLevel);
+    for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
+      fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
+    }
     
     // Update reconciliation targets in actionsStore
     if (initialStateStore.currentFarmState) {
@@ -870,13 +877,6 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
       teEarnedPerEgg 
     } = initialStateStore.loadFromBackup(id, backup, mode);
 
-    // Catch-up calculations (eggs, earnings, population) are now handled 
-    // automatically by computeSnapshot in the engine. We compute the initial 
-    // snapshot first and then sync the results back to the stores.
-    const context = getSimulationContext();
-    const baseState = createBaseEngineState(null);
-    const initialSnapshot = computeSnapshot(baseState, context);
-
     // Initialize virtue store with player's shift count and TE
     virtueStore.setInitialState(initialShiftCount, initialTE);
 
@@ -885,6 +885,13 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
     for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
       fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
     }
+
+    // Catch-up calculations (eggs, earnings, population) are now handled 
+    // automatically by computeSnapshot in the engine. We compute the initial 
+    // snapshot first and then sync the results back to the stores.
+    const context = getSimulationContext();
+    const baseState = createBaseEngineState(null);
+    const initialSnapshot = computeSnapshot(baseState, context);
 
     // Initialize truth eggs store with caught-up data from snapshot
     for (const [egg, amount] of Object.entries(initialSnapshot.eggsDelivered)) {
@@ -918,9 +925,8 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
       initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - earned));
     }
 
-    if (mode !== 'plan_next') {
-      await actionsStore.setInitialSnapshot(initialSnapshot);
-    }
+    // Initialize initial state in actions store
+    await actionsStore.setInitialSnapshot(initialSnapshot);
 
     loading.value = false;
   } catch (e) {

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -153,7 +153,7 @@
                   <button
                     class="btn-premium btn-primary px-5 py-2 mt-auto w-full"
                     :disabled="loading || !playerId"
-                    @click="triggerReconcile"
+                    @click="confirmUnsavedChanges(triggerReconcile)"
                   >
                     Reconcile
                   </button>
@@ -399,7 +399,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
 import TheNavBar from 'ui/components/NavBar.vue';
-import { getSavedPlayerID, savePlayerID, requestFirstContact, iconURL } from 'lib';
+import { getSavedPlayerID, savePlayerID, requestFirstContact } from 'lib';
 import ThePlayerIdForm from 'ui/components/PlayerIdForm.vue';
 import { useInitialStateStore } from '@/stores/initialState';
 import { useActionsStore } from '@/stores/actions';
@@ -407,10 +407,7 @@ import { useVirtueStore } from '@/stores/virtue';
 import { useFuelTankStore } from '@/stores/fuelTank';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useEventsStore } from '@/stores/events';
-import { useCommonResearchStore } from '@/stores/commonResearch';
-import { useHabCapacityStore } from '@/stores/habCapacity';
-import { useShippingCapacityStore } from '@/stores/shippingCapacity';
-import { useSilosStore } from '@/stores/silos';
+
 import { useNotesStore } from '@/stores/notes';
 import ActionHistory from '@/components/ActionHistory.vue';
 import AvailableActions from '@/components/AvailableActions.vue';
@@ -437,6 +434,14 @@ import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
 import type { Action, VirtueEgg } from '@/types';
 import { countTEThresholdsPassed } from '@/lib/truthEggs';
 import { getArtifact, getArtifactLoadoutFromBackup } from '@/lib/artifacts';
+import {
+  initStartFromScratch,
+  initPlanFuture,
+  initContinueCurrent,
+  initReconcile,
+  loadAndSyncBackup,
+  captureReconciliationTargets,
+} from '@/lib/modes';
 
 const playerId = ref(new URLSearchParams(window.location.search).get('playerId') || getSavedPlayerID() || '');
 const loading = ref(false);
@@ -449,10 +454,7 @@ const fuelTankStore = useFuelTankStore();
 const truthEggsStore = useTruthEggsStore();
 const eventsStore = useEventsStore();
 const salesStore = useSalesStore();
-const commonResearchStore = useCommonResearchStore();
-const habCapacityStore = useHabCapacityStore();
-const shippingCapacityStore = useShippingCapacityStore();
-const silosStore = useSilosStore();
+
 const notesStore = useNotesStore();
 const { prepareExecution, completeExecution } = useActionExecutor();
 const { partitionHash, saveActiveDraft, initPersistence, broadcastPresence } = usePersistence();
@@ -709,43 +711,17 @@ function executeClearAll() {
 
 /**
  * Start from Scratch: Full reset.
- * Wipes the action history, clears player data from stores,
- * and resets initial state to defaults — equivalent to a hard refresh.
+ * Delegates to initStartFromScratch mode initializer.
  */
 async function startFromScratch() {
   error.value = '';
-
-  // 1. Wipe action history first to stop any ongoing simulations
-  // and clear the start action's carry-over state.
-  const startAction = actionsStore.getStartAction();
-  if (startAction) {
-    startAction.payload.initialFarmState = undefined;
-    startAction.payload.isQuickContinue = false;
-    startAction.payload.initialEgg = 'curiosity';
+  try {
+    await initStartFromScratch();
+    isHeaderCollapsed.value = true;
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Reset failed';
+    console.error('Start from Scratch error:', e);
   }
-  actionsStore.isReconciling = false;
-  actionsStore.showIncompleteOnly = false;
-  await actionsStore.clearAll();
-
-  // 2. Reset all definition stores to their default/clean states.
-  initialStateStore.$reset();
-
-  // 3. Reset all other stores to their default/clean states
-  virtueStore.$reset();
-  fuelTankStore.$reset();
-  truthEggsStore.$reset();
-  commonResearchStore.$reset();
-  habCapacityStore.$reset();
-  shippingCapacityStore.$reset();
-  silosStore.$reset();
-  notesStore.$reset();
-
-  // 3. Recompute and set a clean initial snapshot from the reset stores.
-  const context = getSimulationContext();
-  const baseState = createBaseEngineState(null);
-  const initialSnapshot = computeSnapshot(baseState, context);
-  await actionsStore.setInitialSnapshot(initialSnapshot);
-  isHeaderCollapsed.value = true;
 }
 
 /**
@@ -762,22 +738,8 @@ async function handleLibraryReconcile(plan: import('@/lib/storage/db').PlanData)
   error.value = '';
 
   try {
-    // 1. Fetch latest backup
-    await submitPlayerId(playerId.value, 'reconcile');
-
-    // Capture the live state for reconciliation before the plan import overwrites initialStateStore
-    if (initialStateStore.currentFarmState) {
-      actionsStore.reconcileFarmState = JSON.parse(JSON.stringify(initialStateStore.currentFarmState));
-    } else {
-      actionsStore.reconcileFarmState = null;
-    }
-    actionsStore.reconcileEggsDelivered = JSON.parse(JSON.stringify(initialStateStore.initialEggsDelivered));
-    actionsStore.reconcileTeEarned = JSON.parse(JSON.stringify(initialStateStore.initialTeEarned));
-
-    // 2. Set reconciliation mode and load the plan
-    actionsStore.isReconciling = true;
-    broadcastPresence(plan.id); // Immediate heartbeat to block other tabs
-    await actionsStore.loadPlanFromLibrary(plan);
+    savePlayerID(playerId.value);
+    await initReconcile(playerId.value, plan, broadcastPresence);
     isHeaderCollapsed.value = true;
   } catch (err) {
     console.error(err);
@@ -801,29 +763,11 @@ async function handleRefreshReconcile() {
     const pHash = await hashID(playerId.value);
     await saveMetadata(pHash, 'rawBackup', backup);
     
-    // Load into state store
-    const { 
-      initialShiftCount, 
-      initialTE, 
-      tankLevel, 
-      virtueFuelAmounts,
-    } = initialStateStore.loadFromBackup(playerId.value, backup, 'reconcile');
+    // Load into state store and sync global stores
+    loadAndSyncBackup(playerId.value, backup, 'reconcile');
 
-    // Sync stores
-    virtueStore.setInitialState(initialShiftCount, initialTE);
-    fuelTankStore.setTankLevel(tankLevel);
-    for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
-      fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
-    }
-    
     // Update reconciliation targets in actionsStore
-    if (initialStateStore.currentFarmState) {
-      actionsStore.reconcileFarmState = JSON.parse(JSON.stringify(initialStateStore.currentFarmState));
-    } else {
-      actionsStore.reconcileFarmState = null;
-    }
-    actionsStore.reconcileEggsDelivered = JSON.parse(JSON.stringify(initialStateStore.initialEggsDelivered));
-    actionsStore.reconcileTeEarned = JSON.parse(JSON.stringify(initialStateStore.initialTeEarned));
+    captureReconciliationTargets();
 
     // No full recalculateAll() needed here, as reconciliation statuses are reactive getters.
   } catch (err) {
@@ -842,15 +786,17 @@ function onFormInput(e: Event) {
   error.value = '';
 }
 
-async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'continue_earnings' | 'continue_elr' | 'reconcile' | 'default' = 'default') {
+/**
+ * Load player data from the server when the player ID form is submitted.
+ * This is NOT a mode initializer — it just fetches player data so the
+ * mode buttons become usable and player info is displayed.
+ */
+async function submitPlayerId(id: string) {
   playerId.value = id;
   savePlayerID(id);
   error.value = '';
   loading.value = true;
-
-  if (mode === 'default') {
-    notesStore.$reset();
-  }
+  notesStore.$reset();
 
   try {
     // Clear existing plan to ensure a fresh start with new player data
@@ -867,63 +813,17 @@ async function submitPlayerId(id: string, mode: 'scratch' | 'plan_next' | 'conti
       console.error('Failed to save raw backup to DB', dbErr);
     }
 
-    // Store the backup data in initial state
-    const { 
-      initialShiftCount, 
-      initialTE, 
-      tankLevel, 
-      virtueFuelAmounts, 
-      eggsDelivered, 
-      teEarnedPerEgg 
-    } = initialStateStore.loadFromBackup(id, backup, mode);
-
-    // Initialize virtue store with player's shift count and TE
-    virtueStore.setInitialState(initialShiftCount, initialTE);
-
-    // Initialize fuel tank store with player's tank data
-    fuelTankStore.setTankLevel(tankLevel);
-    for (const [egg, amount] of Object.entries(virtueFuelAmounts)) {
-      fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
-    }
+    // Load into state store and sync global stores
+    const { teEarnedPerEgg } = loadAndSyncBackup(id, backup, 'default');
 
     // Catch-up calculations (eggs, earnings, population) are now handled 
-    // automatically by computeSnapshot in the engine. We compute the initial 
-    // snapshot first and then sync the results back to the stores.
+    // automatically by computeSnapshot in the engine.
     const context = getSimulationContext();
     const baseState = createBaseEngineState(null);
     const initialSnapshot = computeSnapshot(baseState, context);
-
-    // Initialize truth eggs store with caught-up data from snapshot
-    for (const [egg, amount] of Object.entries(initialSnapshot.eggsDelivered)) {
-      truthEggsStore.setEggsDelivered(egg as VirtueEgg, amount);
-    }
-    for (const [egg, count] of Object.entries(teEarnedPerEgg)) {
-      truthEggsStore.setTEEarned(egg as VirtueEgg, count);
-    }
-
-    // Update initial state store with caught-up values for persistence and future starts
-    if (initialStateStore.currentFarmState) {
-      const farm = initialStateStore.currentFarmState;
-      const egg = initialSnapshot.currentEgg;
-      const newDelivered = initialSnapshot.eggsDelivered[egg] || 0;
-      
-      const extraCash = initialSnapshot.bankValue - baseState.bankValue;
-
-      // Update farm state
-      farm.population = initialSnapshot.population;
-      farm.cash = initialSnapshot.bankValue;
-      farm.cashEarned += Math.max(0, extraCash);
-      farm.deliveredEggs = newDelivered;
-      farm.lastStepTime = context.ascensionStartTime;
-
-      // Update initial state tracking
-      initialStateStore.setInitialEggsDelivered(egg, newDelivered);
-      
-      // Recalculate pending TE for this egg
-      const theoreticalTE = countTEThresholdsPassed(newDelivered);
-      const earned = teEarnedPerEgg[egg];
-      initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - earned));
-    }
+    
+    // Sync farm state and Truth Eggs with caught-up values
+    catchUpFarmState(initialSnapshot, baseState.bankValue, context.ascensionStartTime, teEarnedPerEgg);
 
     // Initialize initial state in actions store
     await actionsStore.setInitialSnapshot(initialSnapshot);
@@ -1021,34 +921,20 @@ async function quickContinueAscension(selection: 'earnings' | 'elr') {
   loading.value = true;
 
   try {
-    // 1. Reset date/time/TZ to current
-    virtueStore.resetToCurrentDateTime();
-    virtueStore.setBankValue(0);
-
-    // 3. Refresh backup (submitPlayerId)
-    await submitPlayerId(playerId.value, selection === 'earnings' ? 'continue_earnings' : 'continue_elr');
-
-    notesStore.$reset();
-
-    // 4. Trigger continue from backup
-    actionsStore.isReconciling = false;
-    await actionsStore.continueFromBackup(true);
-
+    savePlayerID(playerId.value);
+    await initContinueCurrent(playerId.value, selection);
     isHeaderCollapsed.value = true;
-    loading.value = false;
   } catch (e) {
-    loading.value = false;
     error.value = e instanceof Error ? e.message : 'Quick Continue failed';
     console.error('Quick Continue error:', e);
+  } finally {
+    loading.value = false;
   }
 }
 
 /**
  * Plan Next Ascension:
- * 1. Load latest player data (reuses submitPlayerId)
- * 2. Include pending TE
- * 3. Reset ascension date/time/timezone to current values
- * 4. Clear action history (wipe old plan)
+ * Delegates to initPlanFuture mode initializer.
  */
 async function planNextAscension() {
   if (!playerId.value) return;
@@ -1057,64 +943,14 @@ async function planNextAscension() {
   loading.value = true;
 
   try {
-    // 1. Wipe current plan
-    await actionsStore.clearAll();
-
-    // 2. Load latest backup
-    await submitPlayerId(playerId.value, 'plan_next');
-
-    // 3. Include pending TE
-    for (const egg of Object.keys(initialStateStore.initialTePending) as VirtueEgg[]) {
-      const pending = initialStateStore.initialTePending[egg];
-      if (pending > 0) {
-        const currentEarned = initialStateStore.initialTeEarned[egg];
-        const newTotal = Math.min(98, currentEarned + pending);
-        truthEggsStore.setTEEarned(egg, newTotal);
-        initialStateStore.setInitialTePending(egg, 0);
-      }
-    }
-    // Sync back
-    for (const egg of Object.keys(initialStateStore.initialTeEarned) as VirtueEgg[]) {
-      initialStateStore.setInitialEggsDelivered(egg, truthEggsStore.eggsDelivered[egg]);
-      initialStateStore.setInitialTeEarned(egg, truthEggsStore.teEarned[egg]);
-    }
-    virtueStore.setTE(truthEggsStore.totalTE);
-    virtueStore.setInitialTE(truthEggsStore.totalTE);
-
-    // 4. Reset ascension date/time/timezone to current
-    virtueStore.resetToCurrentDateTime();
-
-    // 5. Clear any farm state from a previous Continue so the start action is clean
-    const startAction = actionsStore.getStartAction();
-    if (startAction) {
-      startAction.payload.initialFarmState = undefined;
-      startAction.payload.isQuickContinue = false;
-    }
-
-    // 6. Reset purchase state to defaults (fresh ascension)
-    commonResearchStore.$reset();
-    habCapacityStore.$reset();
-    shippingCapacityStore.$reset();
-    silosStore.$reset();
-    notesStore.$reset();
-    virtueStore.setBankValue(0);
-
-    // 7. Set starting egg to Curiosity
-    virtueStore.setCurrentEgg('curiosity');
-    actionsStore.setInitialEgg('curiosity');
-
-    // 8. Recalculate initial snapshot with updated TE
-    const context = getSimulationContext();
-    const baseState = createBaseEngineState(null);
-    const initialSnapshot = computeSnapshot(baseState, context);
-    await actionsStore.setInitialSnapshot(initialSnapshot);
-
+    savePlayerID(playerId.value);
+    await initPlanFuture(playerId.value);
     isHeaderCollapsed.value = true;
-    loading.value = false;
   } catch (e) {
-    loading.value = false;
     error.value = e instanceof Error ? e.message : 'Plan Next failed';
     console.error('Plan Next Ascension error:', e);
+  } finally {
+    loading.value = false;
   }
 }
 

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -441,6 +441,7 @@ import {
   initReconcile,
   loadAndSyncBackup,
   captureReconciliationTargets,
+  catchUpFarmState,
 } from '@/lib/modes';
 
 const playerId = ref(new URLSearchParams(window.location.search).get('playerId') || getSavedPlayerID() || '');

--- a/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
+++ b/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
@@ -64,8 +64,9 @@
         <!-- Recon Status -->
         <div v-if="actionsStore.isReconciling" class="flex items-center justify-center w-5 sm:w-6">
           <!-- Manual completion / Unaudiated -->
-          <div v-if="isManuallyCompleted || reconciliationStatus === 'na'" class="flex items-center justify-center">
-            <label class="cursor-pointer hover:bg-slate-100 p-0.5 rounded transition-colors" v-tippy="isManuallyCompleted ? 'Manually completed - Click to undo' : 'Not Audited - Click to mark complete'">
+          <div v-if="isManuallyCompleted || reconciliationStatus === 'na' || reconciliationStatus === 'pending'" class="flex items-center justify-center">
+            <label class="cursor-pointer hover:bg-slate-100 p-0.5 rounded transition-colors" 
+                   v-tippy="isManuallyCompleted ? 'Manually completed - Click to undo' : (reconciliationStatus === 'pending' ? 'Pending in-game - Click to mark complete anyway' : 'Not Audited - Click to mark complete')">
               <input 
                 type="checkbox" 
                 :checked="isManuallyCompleted"

--- a/wasmegg/ascension-planner/src/components/EventExpiryDialog.vue
+++ b/wasmegg/ascension-planner/src/components/EventExpiryDialog.vue
@@ -102,8 +102,10 @@ function formatTime(timestamp: number): string {
 function formatDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
   if (h > 0) return `${h}h ${m}m`;
-  return `${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
 }
 </script>
 

--- a/wasmegg/ascension-planner/src/components/PlanLibrary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanLibrary.vue
@@ -4,6 +4,7 @@ import { useActionsStore } from '@/stores/actions';
 import { usePersistence } from '@/composables/usePersistence';
 import { loadLibraryPlans, deletePlanFromLibrary, savePlanToLibrary, type PlanData } from '@/lib/storage/db';
 import { downloadFile } from '@/utils/export';
+import { initLoadPlan } from '@/lib/modes';
 import ConfirmationDialog from '@/components/ConfirmationDialog.vue';
 import ImportCollisionDialog from '@/components/ImportCollisionDialog.vue';
 import PlanAlreadyOpenWarning from '@/components/PlanAlreadyOpenWarning.vue';
@@ -58,7 +59,7 @@ async function loadPlan(plan: PlanData) {
 
   try {
     broadcastPresence(plan.id); // Immediate heartbeat to block other tabs
-    await actionsStore.loadPlanFromLibrary(plan);
+    await initLoadPlan(plan);
     emit('plan-loaded');
   } catch (err) {
     alert('Failed to load plan: ' + err);

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -268,7 +268,7 @@ const eggPlans = computed(() => {
   const fullHabRate = Math.min(S, R * H);
   
   let runningTimeSeconds = 0;
-  const planStartOffset = (actionsStore as any).planStartOffset || 0;
+  const planStartOffset = actionsStore.planStartOffset || 0;
   const baseTime = snapshot.lastStepTime;
 
   return visitOrder.value.map((egg, index) => {
@@ -388,7 +388,7 @@ function adjustEgg(egg: VirtueEgg, delta: number) {
   });
 
   // Update total based on new sum
-  totalTEToGain.value = Object.values(manualGains.value).reduce((sum, v) => sum + (v || 0), 0);
+  totalTEToGain.value = Object.values(manualGains.value).reduce<number>((sum, v) => (sum || 0) + (v || 0), 0);
 }
 
 function rebalance() {

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -1,0 +1,527 @@
+<template>
+  <div class="space-y-6">
+    <!-- Header: Total Gain and Final TE -->
+    <div class="bg-slate-50/50 rounded-xl p-4 border border-slate-100 flex flex-wrap items-center justify-between gap-4">
+      <div class="space-y-1">
+        <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Total TE to Gain</label>
+        <div class="flex items-center gap-3">
+          <button 
+            class="w-8 h-8 rounded-lg bg-white border border-slate-200 flex items-center justify-center text-slate-500 hover:bg-slate-50 active:scale-95 transition-all shadow-sm"
+            @click="adjustTotal(-1)"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" /></svg>
+          </button>
+          <input 
+            type="number"
+            v-model.number="totalTEToGain"
+            class="w-16 bg-white border border-slate-200 rounded-lg px-2 py-1 text-center font-mono-premium font-bold text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900/5 transition-all shadow-sm"
+            @change="handleTotalChange"
+          />
+          <button 
+            class="w-8 h-8 rounded-lg bg-white border border-slate-200 flex items-center justify-center text-slate-500 hover:bg-slate-50 active:scale-95 transition-all shadow-sm"
+            @click="adjustTotal(1)"
+          >
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+          </button>
+        </div>
+      </div>
+
+      <div class="space-y-1">
+        <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400 text-right">Final Total TE</label>
+        <div class="flex items-center justify-end gap-2">
+          <span class="font-mono-premium font-black text-2xl text-slate-900">{{ finalTotalTE }}</span>
+          <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-6 h-6 object-contain" />
+        </div>
+      </div>
+
+      <div class="w-full sm:w-auto">
+        <button 
+          class="w-full sm:w-auto px-4 py-2 rounded-lg font-black text-[10px] uppercase tracking-wider transition-all shadow-sm border"
+          :class="canRebalance ? 'bg-slate-900 text-white border-slate-900 hover:bg-slate-800' : 'bg-white text-slate-300 border-slate-100 cursor-not-allowed'"
+          :disabled="!canRebalance"
+          @click="rebalance"
+        >
+          Rebalance
+        </button>
+      </div>
+    </div>
+
+    <!-- Egg Visit Order -->
+    <div class="space-y-3">
+      <div 
+        v-for="(eggPlan, index) in eggPlans" 
+        :key="eggPlan.egg"
+        class="bg-white rounded-2xl border border-slate-100 shadow-sm overflow-hidden"
+        :class="{ 'ring-1 ring-slate-900/5': eggPlan.isCurrentEgg }"
+      >
+        <div class="px-5 py-4 flex items-center justify-between gap-4">
+          <div class="flex items-center gap-3">
+            <div class="w-10 h-10 rounded-xl bg-slate-50 border border-slate-100 flex items-center justify-center p-1.5 shadow-inner">
+              <img :src="iconURL(`egginc/egg_${eggPlan.egg}.png`, 64)" class="w-full h-full object-contain" />
+            </div>
+            <div>
+              <div class="flex items-center gap-2">
+                <span class="font-black text-[10px] uppercase text-slate-900">{{ VIRTUE_EGG_NAMES[eggPlan.egg] }}</span>
+                <span class="text-slate-600 text-[10px] font-bold">{{ formatDuration(eggPlan.durationSeconds) }}</span>
+                <span v-if="eggPlan.isCurrentEgg" class="px-1.5 py-0.5 bg-slate-900 text-white text-[8px] font-black uppercase tracking-tighter rounded">Current</span>
+              </div>
+              <div class="text-[10px] font-mono-premium text-slate-400 mt-0.5">
+                <span v-if="index === eggPlans.length - 1">Prestige on</span>
+                <span v-else>Shift on</span>
+                <span class="text-slate-500">&nbsp;{{ eggPlan.absoluteTime }}</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <!-- Individual Adjustments -->
+            <div class="flex items-center bg-slate-50 rounded-lg border border-slate-100 p-0.5 shadow-inner">
+              <button 
+                class="w-6 h-6 rounded flex items-center justify-center text-slate-400 hover:text-slate-900 hover:bg-white transition-all active:scale-90"
+                @click="adjustEgg(eggPlan.egg, -1)"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" /></svg>
+              </button>
+              <span class="px-2 text-center text-xs font-mono-premium font-black text-slate-900">
+                {{ eggPlan.targetTE }}
+                <span class="text-indigo-600 font-bold ml-1">(+{{ eggPlan.teToGain }})</span>
+              </span>
+              <button 
+                class="w-6 h-6 rounded flex items-center justify-center text-slate-400 hover:text-slate-900 hover:bg-white transition-all active:scale-90"
+                @click="adjustEgg(eggPlan.egg, 1)"
+              >
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" /></svg>
+              </button>
+            </div>
+
+            <!-- Reorder Controls -->
+            <div v-if="!eggPlan.isCurrentEgg" class="flex flex-col gap-0.5">
+              <button 
+                class="w-6 h-5 flex items-center justify-center text-slate-300 hover:text-slate-900 transition-all"
+                :class="{ 'opacity-0 pointer-events-none': index === 1 }"
+                @click="moveEgg(index, -1)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7" /></svg>
+              </button>
+              <button 
+                class="w-6 h-5 flex items-center justify-center text-slate-300 hover:text-slate-900 transition-all"
+                :class="{ 'opacity-0 pointer-events-none': index === eggPlans.length - 1 }"
+                @click="moveEgg(index, 1)"
+              >
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Summary -->
+    <div v-if="totalTEToGain > 0" class="bg-slate-900 rounded-2xl p-5 text-white shadow-xl shadow-slate-900/20">
+      <div class="flex items-center justify-between">
+        <div class="space-y-1">
+          <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Total Duration</label>
+          <div class="text-xl font-mono-premium font-black">{{ formatDuration(totalDurationSeconds) }}</div>
+        </div>
+        <div class="text-right space-y-1">
+          <label class="block text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">Final Completion</label>
+          <div class="text-sm font-bold text-slate-200 italic">{{ finalAbsoluteTime }}</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Apply Button -->
+    <div class="pt-2">
+      <button 
+        class="btn-premium btn-primary w-full py-4 text-xs font-black uppercase tracking-[0.3em] shadow-xl"
+        :disabled="totalTEToGain <= 0"
+        @click="handleApply"
+      >
+        Apply Bulk TE Plan
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import { iconURL, shiftCost } from 'lib';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useVirtueStore } from '@/stores/virtue';
+import { useActionsStore } from '@/stores/actions';
+import { useActionExecutor } from '@/composables/useActionExecutor';
+import { computeDependencies } from '@/lib/actions/executor';
+import { formatNumber, formatDuration, formatAbsoluteTime } from '@/lib/format';
+import { generateActionId, VIRTUE_EGG_NAMES, VIRTUE_EGGS, type VirtueEgg } from '@/types';
+import { TE_BREAKPOINTS, countTEThresholdsPassed, MAX_TE, eggsNeededForTE } from '@/lib/truthEggs';
+import { integrateRate } from '@/engine/apply/math';
+
+const truthEggsStore = useTruthEggsStore();
+const virtueStore = useVirtueStore();
+const actionsStore = useActionsStore();
+
+const totalTEToGain = ref(15);
+const visitOrder = ref<VirtueEgg[]>([]);
+
+// Per-egg gain overrides (to support manual adjustments)
+const manualGains = ref<Record<VirtueEgg, number | null>>({
+  curiosity: null,
+  integrity: null,
+  humility: null,
+  resilience: null,
+  kindness: null,
+});
+
+// Current starting stats per egg (accounts for pending TE in the plan)
+const eggStartStates = computed(() => {
+  const stats: Record<VirtueEgg, { te: number; delivered: number }> = {} as any;
+  const snapshot = actionsStore.effectiveSnapshot;
+  
+  for (const egg of VIRTUE_EGGS) {
+    const delivered = snapshot.eggsDelivered[egg] || 0;
+    const earned = snapshot.teEarned?.[egg] || 0;
+    const thresholds = countTEThresholdsPassed(delivered);
+    stats[egg] = {
+      te: Math.max(earned, thresholds),
+      delivered: delivered,
+    };
+  }
+  return stats;
+});
+
+const currentTotalTE = computed(() => {
+  return Object.values(eggStartStates.value).reduce((sum, s) => sum + s.te, 0);
+});
+
+const finalTotalTE = computed(() => currentTotalTE.value + totalTEToGain.value);
+
+/**
+ * The Greedy Allocation Algorithm
+ */
+function calculateGreedyGains(total: number) {
+  const gains: Record<VirtueEgg, number> = {} as any;
+  VIRTUE_EGGS.forEach(e => gains[e] = 0);
+
+  const working = VIRTUE_EGGS.map(egg => ({
+    egg,
+    currentTE: eggStartStates.value[egg].te,
+    currentDelivered: eggStartStates.value[egg].delivered,
+  }));
+
+  for (let i = 0; i < total; i++) {
+    let bestEgg: VirtueEgg | null = null;
+    let bestCost = Infinity;
+
+    for (const w of working) {
+      if (w.currentTE >= MAX_TE) continue;
+
+      const nextThreshold = TE_BREAKPOINTS[w.currentTE];
+      const cost = Math.max(0, nextThreshold - w.currentDelivered);
+
+      if (cost < bestCost) {
+        bestCost = cost;
+        bestEgg = w.egg;
+      }
+    }
+
+    if (!bestEgg) break;
+
+    gains[bestEgg]++;
+    const wEgg = working.find(w => w.egg === bestEgg)!;
+    wEgg.currentTE++;
+    wEgg.currentDelivered = TE_BREAKPOINTS[wEgg.currentTE - 1];
+  }
+
+  return gains;
+}
+
+// Current distribution based on greedy logic or manual overrides
+const distributedGains = computed(() => {
+  // If we have manual overrides that sum to the total, use them.
+  // Otherwise, fallback to greedy for the remaining.
+  // Actually, for simplicity in Phase 1: if ANY are manual, use manual. 
+  // But the plan says Rebalance button resets everything to greedy.
+  
+  const anyManual = Object.values(manualGains.value).some(v => v !== null);
+  if (anyManual) {
+    const gains: Record<VirtueEgg, number> = {} as any;
+    VIRTUE_EGGS.forEach(e => gains[e] = manualGains.value[e] ?? 0);
+    return gains;
+  }
+  
+  return calculateGreedyGains(totalTEToGain.value);
+});
+
+const canRebalance = computed(() => {
+  const greedy = calculateGreedyGains(totalTEToGain.value);
+  return VIRTUE_EGGS.some(e => distributedGains.value[e] !== greedy[e]);
+});
+
+const eggPlans = computed(() => {
+  const currentEgg = actionsStore.effectiveSnapshot.currentEgg as VirtueEgg;
+  const snapshot = actionsStore.effectiveSnapshot;
+  
+  const IHR = snapshot.offlineIHR / 60;
+  const R = snapshot.ratePerChickenPerSecond;
+  const S = snapshot.shippingCapacity;
+  const H = snapshot.habCapacity;
+  const fullHabRate = Math.min(S, R * H);
+  
+  let runningTimeSeconds = 0;
+  const planStartOffset = (actionsStore as any).planStartOffset || 0;
+  const baseTime = snapshot.lastStepTime;
+
+  return visitOrder.value.map((egg, index) => {
+    const start = eggStartStates.value[egg];
+    const gain = distributedGains.value[egg];
+    
+    let durationSeconds = 0;
+    
+    if (gain > 0) {
+      const eggsToLay = eggsNeededForTE(start.delivered, start.te + gain);
+      let currentPop = egg === currentEgg ? snapshot.population : 1;
+      
+      // 1. Hab fill phase
+      if (currentPop < H) {
+        const fillTime = IHR > 0 ? (H - currentPop) / IHR : 0;
+        durationSeconds += fillTime;
+        
+        const eggsDuringFill = integrateRate(fillTime, currentPop, IHR, R, S, H);
+        const remainingToLay = Math.max(0, eggsToLay - eggsDuringFill);
+        
+        // 2. Shipping phase at full capacity
+        durationSeconds += fullHabRate > 0 ? remainingToLay / fullHabRate : 0;
+      } else {
+        durationSeconds += fullHabRate > 0 ? eggsToLay / fullHabRate : 0;
+      }
+    }
+
+    const completionTime = baseTime + runningTimeSeconds + durationSeconds;
+    
+    const plan = {
+      egg,
+      isCurrentEgg: egg === currentEgg,
+      currentTE: start.te,
+      targetTE: start.te + gain,
+      teToGain: gain,
+      durationSeconds,
+      displayTime: formatSimTime(baseTime + runningTimeSeconds),
+      absoluteTime: formatAbsoluteTime(completionTime - planStartOffset, actionsStore.ascensionStartTime),
+    };
+
+    runningTimeSeconds += durationSeconds;
+    return plan;
+  });
+});
+
+const totalDurationSeconds = computed(() => {
+  return eggPlans.value.reduce((sum, p) => sum + p.durationSeconds, 0);
+});
+
+const finalAbsoluteTime = computed(() => {
+  const lastPlan = eggPlans.value[eggPlans.value.length - 1];
+  return lastPlan?.absoluteTime || '---';
+});
+
+/**
+ * Format relative simulation time: "Day X, H:MM AM/PM"
+ */
+function formatSimTime(seconds: number) {
+  // Use current time as fallback for Continue Ascension if store start time is missing
+  const startTime = actionsStore.ascensionStartTime || (Date.now() / 1000);
+  
+  if (isNaN(seconds) || seconds === 0) return 'Day 1, 12:00 AM';
+
+  const relativeSeconds = Math.max(0, seconds - startTime);
+  const day = Math.floor(relativeSeconds / 86400) + 1;
+  const hour = Math.floor((relativeSeconds % 86400) / 3600);
+  const minute = Math.floor((relativeSeconds % 3600) / 60);
+  
+  const period = hour >= 12 ? 'PM' : 'AM';
+  const displayHour = hour % 12 || 12;
+  const displayMinute = minute.toString().padStart(2, '0');
+  
+  return `Day ${day}, ${displayHour}:${displayMinute} ${period}`;
+}
+
+// Initialization
+onMounted(() => {
+  const currentEgg = actionsStore.effectiveSnapshot.currentEgg as VirtueEgg;
+  // Current egg first, then others in standard order
+  visitOrder.value = [
+    currentEgg,
+    ...VIRTUE_EGGS.filter(e => e !== currentEgg)
+  ];
+});
+
+// Methods
+function adjustTotal(delta: number) {
+  const newTotal = Math.max(0, totalTEToGain.value + delta);
+  const maxPossibleGain = Object.values(eggStartStates.value).reduce((sum, s) => sum + (MAX_TE - s.te), 0);
+  totalTEToGain.value = Math.min(newTotal, maxPossibleGain);
+  rebalance();
+}
+
+function handleTotalChange() {
+  const maxPossibleGain = Object.values(eggStartStates.value).reduce((sum, s) => sum + (MAX_TE - s.te), 0);
+  totalTEToGain.value = Math.min(Math.max(0, totalTEToGain.value), maxPossibleGain);
+  rebalance();
+}
+
+function adjustEgg(egg: VirtueEgg, delta: number) {
+  // Capture current state before we start modifying dependencies
+  const currentDist = { ...distributedGains.value };
+  const start = eggStartStates.value[egg];
+  const currentGain = currentDist[egg];
+  const newGain = Math.max(0, Math.min(MAX_TE - start.te, currentGain + delta));
+  
+  if (newGain === currentGain) return;
+
+  // Set the manual value for the adjusted egg
+  manualGains.value[egg] = newGain;
+  
+  // Freeze all other eggs to their current values to enter "manual mode" cleanly
+  VIRTUE_EGGS.forEach(e => {
+    if (e !== egg && manualGains.value[e] === null) {
+      manualGains.value[e] = currentDist[e];
+    }
+  });
+
+  // Update total based on new sum
+  totalTEToGain.value = Object.values(manualGains.value).reduce((sum, v) => sum + (v || 0), 0);
+}
+
+function rebalance() {
+  VIRTUE_EGGS.forEach(e => manualGains.value[e] = null);
+}
+
+function moveEgg(index: number, delta: number) {
+  const newIndex = index + delta;
+  if (newIndex < 1 || newIndex >= visitOrder.value.length || index < 1) return;
+  
+  const arr = [...visitOrder.value];
+  const temp = arr[index];
+  arr[index] = arr[newIndex];
+  arr[newIndex] = temp;
+  visitOrder.value = arr;
+}
+
+/**
+ * PHASE 4: Apply Workflow
+ * Generates all actions in a single batch.
+ */
+async function handleApply() {
+  const execute = async (action: any) => {
+    if (actionsStore.editingGroupId) {
+      await actionsStore.insertAction(action);
+    } else {
+      actionsStore.pushAction(action);
+    }
+  };
+
+  actionsStore.startBatch();
+  
+  try {
+    for (const plan of eggPlans.value) {
+      if (plan.teToGain <= 0) continue;
+
+      // 1. If not current egg, we need to SHIFT first
+      if (!plan.isCurrentEgg) {
+        const snapshot = actionsStore.effectiveSnapshot;
+        const fromEgg = snapshot.currentEgg;
+        const toEgg = plan.egg;
+        const newShiftCount = snapshot.shiftCount + 1;
+        const cost = shiftCost(snapshot.soulEggs, snapshot.shiftCount);
+
+        const payload = { fromEgg, toEgg, newShiftCount };
+        await execute({
+          id: generateActionId(),
+          timestamp: Date.now(),
+          type: 'shift' as const,
+          payload,
+          cost,
+          dependsOn: computeDependencies(
+            'shift',
+            payload,
+            actionsStore.actionsBeforeInsertion,
+            actionsStore.initialSnapshot.researchLevels
+          ),
+        });
+        
+        // Use the newly shifted egg for events
+        actionsStore.pushRelevantEvents(toEgg);
+      }
+
+      // 2. Wait for Full Habs
+      {
+        const snapshot = actionsStore.effectiveSnapshot;
+        if (snapshot.population < snapshot.habCapacity) {
+          const IHR = snapshot.offlineIHR / 60;
+          const chickensNeeded = Math.max(0, snapshot.habCapacity - snapshot.population);
+          const totalTimeSeconds = IHR > 0 ? chickensNeeded / IHR : 0;
+
+          const payload = {
+            habCapacity: snapshot.habCapacity,
+            ihr: snapshot.offlineIHR,
+            currentPopulation: snapshot.population,
+            totalTimeSeconds,
+          };
+
+          await execute({
+            id: generateActionId(),
+            timestamp: Date.now(),
+            type: 'wait_for_full_habs' as const,
+            payload,
+            cost: 0,
+            dependsOn: computeDependencies(
+              'wait_for_full_habs',
+              payload,
+              actionsStore.actionsBeforeInsertion,
+              actionsStore.initialSnapshot.researchLevels
+            ),
+          });
+        }
+      }
+
+      // 3. Wait for TE
+      {
+        const snapshot = actionsStore.effectiveSnapshot;
+        const egg = snapshot.currentEgg as VirtueEgg;
+        const eggsToLay = eggsNeededForTE(snapshot.eggsDelivered[egg], plan.targetTE);
+        
+        const payload = {
+          egg,
+          targetTE: plan.targetTE,
+          teGained: plan.teToGain,
+          eggsToLay,
+          timeSeconds: plan.durationSeconds,
+          startEggsDelivered: snapshot.eggsDelivered[egg] || 0,
+          startTE: plan.currentTE,
+        };
+
+        await execute({
+          id: generateActionId(),
+          timestamp: Date.now(),
+          type: 'wait_for_te' as const,
+          payload,
+          cost: 0,
+          dependsOn: computeDependencies(
+            'wait_for_te',
+            payload,
+            actionsStore.actionsBeforeInsertion,
+            actionsStore.initialSnapshot.researchLevels
+          ),
+        });
+      }
+    }
+  } finally {
+    await actionsStore.commitBatch();
+  }
+}
+</script>
+
+<style scoped>
+.font-mono-premium {
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -241,7 +241,6 @@ const distributedGains = computed(() => {
   // Otherwise, fallback to greedy for the remaining.
   // Actually, for simplicity in Phase 1: if ANY are manual, use manual. 
   // But the plan says Rebalance button resets everything to greedy.
-  
   const anyManual = Object.values(manualGains.value).some(v => v !== null);
   if (anyManual) {
     const gains: Record<VirtueEgg, number> = {} as any;

--- a/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
@@ -34,6 +34,38 @@
       </div>
     </div>
 
+    <!-- Bulk Wait for TE Section -->
+    <div
+      class="bg-white rounded-2xl border border-slate-100 overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md"
+    >
+      <button
+        class="w-full px-5 py-4 bg-slate-50/50 flex justify-between items-center hover:bg-white transition-colors group"
+        @click="bulkTEExpanded = !bulkTEExpanded"
+      >
+        <div class="flex items-center gap-3">
+          <div
+            class="w-8 h-8 rounded-xl bg-white border border-slate-200/50 shadow-sm flex items-center justify-center p-1.5 group-hover:scale-110 transition-transform"
+          >
+            <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-full h-full object-contain" />
+          </div>
+          <h3 class="font-black text-[10px] uppercase tracking-[0.2em] text-slate-500">Bulk Wait for TE</h3>
+        </div>
+        <svg
+          class="w-5 h-5 text-slate-300 transition-transform duration-300"
+          :class="{ 'rotate-180 text-slate-900': bulkTEExpanded }"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div v-show="bulkTEExpanded" class="p-6 border-t border-slate-50">
+        <BulkWaitForTEActions />
+      </div>
+    </div>
+
+
     <!-- Wait for Full Habs Section -->
     <div
       class="bg-white rounded-2xl border border-slate-100 overflow-hidden shadow-sm transition-all duration-300 hover:shadow-md"
@@ -235,6 +267,7 @@ import { ref, computed } from 'vue';
 import { iconURL } from 'lib';
 import { useActionsStore } from '@/stores/actions';
 import WaitForTEActions from './WaitForTEActions.vue';
+import BulkWaitForTEActions from './BulkWaitForTEActions.vue';
 import WaitForMissionsActions from './WaitForMissionsActions.vue';
 import WaitForTimeActions from './WaitForTimeActions.vue';
 import WaitForFullHabsActions from './WaitForFullHabsActions.vue';
@@ -248,6 +281,7 @@ const isHumility = computed(() => actionsStore.effectiveSnapshot.currentEgg === 
 const isCuriosity = computed(() => actionsStore.effectiveSnapshot.currentEgg === 'curiosity');
 
 const teExpanded = ref(false);
+const bulkTEExpanded = ref(false);
 const habsExpanded = ref(false);
 const missionsExpanded = ref(false);
 const gemsExpanded = ref(false);

--- a/wasmegg/ascension-planner/src/lib/actions/eventThresholds.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/eventThresholds.ts
@@ -73,10 +73,9 @@ export function checkEventCrossing(
     const completionTimeAbs = planStartTimeSecs + (completionTimeSim - planStartOffset);
 
     return {
-        // We warn if it completes after the threshold. 
-        // We no longer strictly check if currentSimTime < endTimeSim to handle cases 
-        // where the user is already slightly past the threshold but the event is still toggled on.
-        isCrossed: completionTimeSim > endTimeSim,
+        // We warn if it completes at least 1 second after the threshold. 
+        // This avoids nuisance warnings for sub-second overlaps.
+        isCrossed: completionTimeSim >= endTimeSim + 1,
         endTime: endTimeAbs,
         completionTime: completionTimeAbs,
     };

--- a/wasmegg/ascension-planner/src/lib/actions/executor.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/executor.ts
@@ -161,10 +161,14 @@ export function getExecutor<T extends ActionType>(type: T): ActionExecutor<T> {
 export function computeDependencies(
   type: ActionType,
   payload: ActionPayloadMap[ActionType],
-  existingActions: Action[],
+  existingActions: Action[] = [],
   initialResearchLevels: Record<string, number> = {}
 ): string[] {
   const deps: string[] = [];
+
+  if (!existingActions || !Array.isArray(existingActions)) {
+    return [];
+  }
 
   // 1. Every action depends on the most recent shift/start_ascension (the "group header")
   // This ensures that undoing a shift also undoes all actions performed during that shift.

--- a/wasmegg/ascension-planner/src/lib/modes/.agent_instructions.md
+++ b/wasmegg/ascension-planner/src/lib/modes/.agent_instructions.md
@@ -1,0 +1,14 @@
+# AI Agent Instructions for Ascension Mode Management
+
+If you are an AI agent working on the `ascension-planner` codebase, you MUST follow these steps before proposing or implementing any changes to the initialization, store hydration, or mode-switching logic:
+
+1.  **Read the Reference**: Open and read `src/lib/modes/README.md`.
+2.  **Verify the Contract**: Locate the "State Contract Matrix" in that file.
+3.  **Identify the Target Mode**: Determine which of the 5 modes (Scratch, Plan Future, Continue, Reconcile, Load Plan) your task affects.
+4.  **Enforce Isolation**: 
+    -   NEVER add mode-specific logic to `submitPlayerId` in `App.vue`.
+    -   NEVER modify `resetAllStores` unless you are adding a new store that must be cleared for EVERY mode.
+    -   If a bug is mode-specific, fix it ONLY in the corresponding `init<ModeName>.ts` file.
+5.  **Single Snapshot Rule**: Ensure that any new initialization path computes the snapshot exactly once at the end of the chain using `actionsStore.setInitialSnapshot`.
+
+Failure to follow these instructions will likely result in "whack-a-mole" bugs where fixing one mode breaks another.

--- a/wasmegg/ascension-planner/src/lib/modes/README.md
+++ b/wasmegg/ascension-planner/src/lib/modes/README.md
@@ -1,0 +1,77 @@
+# Ascension Planner: Mode Initialization Reference & AI Instructions
+
+> [!IMPORTANT]
+> **AI INSTRUCTIONS**: Whenever you are asked to modify, debug, or answer questions about the initialization of an ascension session (Start from Scratch, Plan Future, Continue Current, Reconcile, or Load Plan), you **MUST** read this file in its entirety before proposing code changes. This ensures you maintain the strict state isolation contracts and do not introduce regressions across modes.
+
+## The 5 Modes: Overview
+
+There are 5 distinct ways to enter an ascension. Each has a dedicated initializer in `src/lib/modes/`.
+
+1.  **Start from Scratch** (`initStartFromScratch`): No backup data. Complete reset to defaults.
+2.  **Plan Future Ascension** (`initPlanFuture`): Uses global progress (epic research, artifacts, TE, fuel) but resets farm state (research, habs, bank=0) and rolls pending TE into earned.
+3.  **Continue Current Ascension** (`initContinueCurrent`): Carries forward the current live farm state into the plan.
+4.  **Reconcile** (`initReconcile`): Compares a saved plan against live backup data.
+5.  **Load Saved Plan** (`initLoadPlan`): Hydrates all stores from a saved plan's serialized state.
+
+---
+
+## 1. The State Contract Matrix
+
+Every mode starts by calling `resetAllStores()` to guarantee a clean baseline. The table below describes the **expected final state** after initialization completes.
+
+| Store / Field | Start from Scratch | Plan Future | Continue Current | Reconcile | Load Saved Plan |
+|---|---|---|---|---|---|
+| **actions** | `[start]` + auto wait | `[start]` + auto wait | `[start + events]` | from plan | from plan |
+| **start.initialEgg** | `'curiosity'` | `'curiosity'` | from backup farm | from plan | from plan |
+| **start.initialFarmState** | `undefined` | `undefined` | from backup farm | from plan | from plan |
+| **start.isQuickContinue** | `false` | `false` | `true` | from plan | from plan |
+| **initialState.hasData** | `false` | `true` | `true` | `true` | `true` (hydrated) |
+| **initialState.isContinuing** | `false` | `false` | `true` | `false` | from plan |
+| **initialState.epicResearch** | defaults | from backup | from backup | from plan | from plan |
+| **initialState.artifactSets** | defaults | optimal earnings | backup loadout | from plan | from plan |
+| **virtue.currentEgg** | `'curiosity'` | `'curiosity'` | from backup farm | from plan | from plan |
+| **virtue.te** | `0` | backup TE + pending | from backup | from plan | from plan |
+| **virtue.bankValue** | `0` | `0` | from backup farm | from plan | from plan |
+| **commonResearch** | defaults (0) | defaults (0) | from backup farm | from plan | from plan |
+| **habCapacity** | defaults | defaults | from backup farm | from plan | from plan |
+| **silos.siloCount** | 1 (default) | 1 (reset) | from backup farm | from plan | from plan |
+| **actionsStore.isReconciling** | `false` | `false` | `false` | `true` | `false` |
+| **reconcileFarmState** | `null` | `null` | `null` | from live backup | `null` |
+
+---
+
+## 2. Initialization Flow Patterns
+
+### Pattern A: Clean State Baseline
+Every mode **MUST** call `resetAllStores()` as its first step.
+-   Clears all Pinia stores to defaults.
+-   Resets the `actionsStore` and clears the `start_ascension` payload.
+-   Ensures no state leaks from a previous session (e.g., `isReconciling` flags).
+
+### Pattern B: The Pure Fetch
+Backup fetching is done via `fetchPlayerBackup(playerId)`.
+-   This function is **pure data**. It fetches the backup and saves it to IndexedDB but **does not touch any stores**.
+-   The mode initializer is responsible for taking the returned data and populating the stores.
+
+### Pattern C: Single Snapshot Computation
+Unlike the old interleaved code, each mode now computes the initial snapshot **exactly once** at the very end of the initialization sequence.
+1.  Reset stores.
+2.  Populate stores from backup/plan.
+3.  `const initialSnapshot = computeSnapshot(...)`
+4.  `await actionsStore.setInitialSnapshot(initialSnapshot)`
+
+---
+
+## 3. Directory Structure
+
+-   `src/lib/modes/index.ts`: Barrel file exporting all initializers.
+-   `src/lib/modes/reset.ts`: Contains `resetAllStores()`.
+-   `src/lib/modes/fetchBackup.ts`: Contains `fetchPlayerBackup()`.
+-   `src/lib/modes/*.ts`: Individual mode initializers.
+
+## 4. Troubleshooting Cross-Mode Bugs
+
+If fixing a bug in "Plan Future" breaks "Continue Current":
+1.  Verify that you didn't add shared logic to `resetAllStores` that has side effects.
+2.  Check `initialStateStore.loadFromBackup`. Ensure the `mode` parameter is correctly handled and not setting global state that affects other modes.
+3.  Ensure you are not modifying `App.vue`'s `submitPlayerId` in a way that assumes it's being used for a specific mode (it is now only used for the initial "Login/Fetch" and its mode is always `'default'`).

--- a/wasmegg/ascension-planner/src/lib/modes/continueCurrent.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/continueCurrent.ts
@@ -1,0 +1,61 @@
+/**
+ * @module initContinueCurrent
+ * @description Mode C: Continue Current Ascension
+ *
+ * Contract:
+ * - Fresh backup loaded (everything)
+ * - Farm-specific stores populated from backup farm (research, habs, vehicles, silos)
+ * - Start action: egg from backup farm, farm state = backup farm, isQuickContinue=true
+ * - isContinuing=true (createBaseEngineState uses farm data)
+ * - Ascension date/time = now
+ * - Active events auto-pushed (earnings boost, relevant sales)
+ * - Artifacts: depends on selection
+ *   - 'earnings': backup loadout as earnings set
+ *   - 'elr': backup loadout as elr set + computed optimal earnings
+ *
+ * Key invariant: start_action.initialFarmState MUST be set, isContinuing MUST be true.
+ */
+
+import { resetAllStores } from './reset';
+import { fetchPlayerBackup } from './fetchBackup';
+import { loadAndSyncBackup, catchUpFarmState } from './utils';
+import { useActionsStore } from '@/stores/actions';
+import { useInitialStateStore } from '@/stores/initialState';
+import { useVirtueStore } from '@/stores/virtue';
+import { computeSnapshot } from '@/engine/compute';
+import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
+
+export async function initContinueCurrent(
+  playerId: string,
+  artifactSet: 'earnings' | 'elr'
+): Promise<void> {
+  // 1. Clean slate
+  await resetAllStores();
+
+  // 2. Fetch backup
+  const { backup } = await fetchPlayerBackup(playerId);
+
+  // 3. Load from backup and sync global stores
+  const initialStateStore = useInitialStateStore();
+  const mode = artifactSet === 'earnings' ? 'continue_earnings' as const : 'continue_elr' as const;
+  const { teEarnedPerEgg } = loadAndSyncBackup(playerId, backup, mode);
+
+  // 4. Continue-specific virtue store setup
+  const virtueStore = useVirtueStore();
+  virtueStore.resetToCurrentDateTime();
+  virtueStore.setBankValue(0); // Will be overridden by continueFromBackup
+
+  // 5. Compute a catch-up snapshot and sync farm state
+  //    (backup may be hours old — simulate time passage for egg delivery)
+  const context = getSimulationContext();
+  const baseState = createBaseEngineState(null);
+  const catchUpSnapshot = computeSnapshot(baseState, context);
+
+  catchUpFarmState(catchUpSnapshot, baseState.bankValue, context.ascensionStartTime, teEarnedPerEgg);
+
+  // 6. Continue from backup — sets up start action with farm state,
+  //    populates farm-specific stores, computes final snapshot, pushes events
+  const actionsStore = useActionsStore();
+  actionsStore.isReconciling = false;
+  await actionsStore.continueFromBackup(true);
+}

--- a/wasmegg/ascension-planner/src/lib/modes/fetchBackup.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/fetchBackup.ts
@@ -1,0 +1,46 @@
+/**
+ * @module fetchBackup
+ * @description Pure data-fetching for player backups. No store mutations.
+ *
+ * Extracted from the old `submitPlayerId` function in App.vue, which combined
+ * data fetching with store initialization. Each mode initializer calls this
+ * independently and handles its own store population.
+ */
+
+import { requestFirstContact } from 'lib';
+import type { ei } from 'lib';
+import { hashID, saveMetadata } from '@/lib/storage/db';
+
+export interface BackupResult {
+  /** The raw protobuf backup from the server */
+  backup: ei.IBackup;
+  /** The hashed player ID (used as a DB partition key) */
+  pHash: string;
+}
+
+/**
+ * Fetch a player's backup from the server and cache it in IndexedDB.
+ *
+ * This is a **pure data operation** — it does NOT mutate any Pinia stores.
+ * Each mode initializer is responsible for populating stores from the returned
+ * backup according to its own contract.
+ *
+ * @throws {Error} If the backup cannot be fetched (network error, invalid ID, etc.)
+ */
+export async function fetchPlayerBackup(playerId: string): Promise<BackupResult> {
+  const data = await requestFirstContact(playerId);
+  if (!data.backup) {
+    throw new Error('Could not fetch player backup');
+  }
+
+  // Persist to IndexedDB for offline access / cross-session reuse
+  const pHash = await hashID(playerId);
+  try {
+    await saveMetadata(pHash, 'rawBackup', data.backup);
+  } catch (dbErr) {
+    console.error('Failed to save raw backup to DB', dbErr);
+    // Non-fatal — continue with the in-memory backup
+  }
+
+  return { backup: data.backup, pHash };
+}

--- a/wasmegg/ascension-planner/src/lib/modes/index.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @module modes
+ * @description Ascension Planner mode initialization system.
+ *
+ * IMPORTANT FOR AI & DEVELOPERS:
+ * There are 5 distinct entry modes for an ascension. Each has strict state
+ * contract requirements. BEFORE modifying any of these flows, you MUST
+ * read the documentation in ./README.md to understand the isolation logic.
+ *
+ * Infrastructure:
+ *   - fetchPlayerBackup: Pure data fetch, no store mutations
+ *   - resetAllStores: Shared baseline reset for all modes
+ *
+ * Mode initializers:
+ *   - initStartFromScratch: Mode A — full reset, no backup
+ *   - initLoadPlan: Mode E — stores hydrated from saved plan
+ *   - initPlanFuture: Mode B — backup for global progress, farm zeroed
+ *   - initContinueCurrent: Mode C — backup with farm state carried forward
+ *   - initReconcile: Mode D — backup for comparison, plan from library
+ */
+
+export { fetchPlayerBackup, type BackupResult } from './fetchBackup';
+export { resetAllStores } from './reset';
+export { initStartFromScratch } from './startFromScratch';
+export { initLoadPlan } from './loadPlan';
+export { initPlanFuture } from './planFuture';
+export { initContinueCurrent } from './continueCurrent';
+export { initReconcile } from './reconcile';
+export * from './utils';

--- a/wasmegg/ascension-planner/src/lib/modes/loadPlan.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/loadPlan.ts
@@ -1,0 +1,30 @@
+/**
+ * @module initLoadPlan
+ * @description Mode E: Load Saved Plan
+ *
+ * Contract:
+ * - All stores hydrated from the plan's serialized state
+ * - No backup fetch needed
+ * - Not reconciling
+ * - Actions loaded from plan
+ * - activePlanId set to the plan's ID
+ */
+
+import { resetAllStores } from './reset';
+import { useActionsStore } from '@/stores/actions';
+import type { PlanData } from '@/lib/storage/db';
+
+export async function initLoadPlan(plan: PlanData): Promise<void> {
+  // 1. Clean slate — prevents stale state from previous modes
+  //    (e.g. isReconciling=true, reconcileFarmState still set)
+  await resetAllStores();
+
+  // 2. Load the plan — importPlan internally calls importPlanLogic which:
+  //    - Hydrates initialStateStore, virtueStore, fuelTankStore, truthEggsStore, notesStore
+  //    - Sets actions from the plan
+  //    - Computes initial snapshot from hydrated stores
+  //    - Recalculates (or skips if pre-calculated)
+  const actionsStore = useActionsStore();
+  actionsStore.activePlanId = plan.id;
+  await actionsStore.importPlan(JSON.stringify(plan.data));
+}

--- a/wasmegg/ascension-planner/src/lib/modes/planFuture.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/planFuture.ts
@@ -1,0 +1,59 @@
+/**
+ * @module initPlanFuture
+ * @description Mode B: Plan Future Ascension
+ *
+ * Contract:
+ * - Fresh backup loaded for global progress (epic research, artifacts, TE, fuel)
+ * - Pending TE rolled into earned TE (claimed at ascension)
+ * - Farm-specific stores ZEROED (research, habs, vehicles, silos, bank)
+ * - Start action: egg=curiosity, no farm state, no quick continue
+ * - Ascension date/time = now
+ * - Artifacts: optimal earnings set
+ * - "Wait for Full Habs" auto-added by setInitialSnapshot
+ *
+ * Key invariant: currentFarmState is populated by loadFromBackup but NOT used
+ * (isContinuing=false, start action has no farm state).
+ */
+
+import { resetAllStores } from './reset';
+import { fetchPlayerBackup } from './fetchBackup';
+import { loadAndSyncBackup, rollUpPendingTE } from './utils';
+import { useActionsStore } from '@/stores/actions';
+import { useVirtueStore } from '@/stores/virtue';
+import { computeSnapshot } from '@/engine/compute';
+import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
+
+export async function initPlanFuture(playerId: string): Promise<void> {
+  // 1. Clean slate
+  await resetAllStores();
+
+  // 2. Fetch backup
+  const { backup } = await fetchPlayerBackup(playerId);
+
+  // 3. Load global progress from backup and sync stores
+  loadAndSyncBackup(playerId, backup, 'plan_next');
+
+  // 4. Roll pending TE into earned (they'll be claimed at ascension)
+  rollUpPendingTE();
+
+  // 5. Plan-specific setup
+  const virtueStore = useVirtueStore();
+  virtueStore.resetToCurrentDateTime();
+  virtueStore.setBankValue(0);
+  virtueStore.setCurrentEgg('curiosity');
+
+  // 6. Ensure start action is clean (resetAllStores already did this, but explicit)
+  const actionsStore = useActionsStore();
+  const startAction = actionsStore.getStartAction();
+  if (startAction) {
+    startAction.payload.initialFarmState = undefined;
+    startAction.payload.isQuickContinue = false;
+    startAction.payload.initialEgg = 'curiosity';
+  }
+
+  // 7. Compute and set initial snapshot
+  const context = getSimulationContext();
+  const baseState = createBaseEngineState(null);
+  const initialSnapshot = computeSnapshot(baseState, context);
+  await actionsStore.setInitialSnapshot(initialSnapshot);
+}

--- a/wasmegg/ascension-planner/src/lib/modes/reconcile.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/reconcile.ts
@@ -1,0 +1,57 @@
+/**
+ * @module initReconcile
+ * @description Mode D: Reconcile Plan
+ *
+ * Contract:
+ * - Fresh backup loaded for live comparison data
+ * - Plan loaded from library (stores hydrated from plan data, actions from plan)
+ * - isReconciling=true
+ * - reconcileFarmState = snapshot of live farm from backup
+ * - reconcileEggsDelivered / reconcileTeEarned = live values from backup
+ * - Plan's stores NOT overwritten by backup (backup is only for comparison)
+ *
+ * Ordering is critical:
+ * 1. Fetch backup (populates initialStateStore with live data)
+ * 2. Capture live comparison targets BEFORE plan import overwrites stores
+ * 3. Load plan from library (overwrites stores with plan data via hydrate)
+ * 4. Set reconciliation mode and comparison targets
+ */
+
+import { resetAllStores } from './reset';
+import { fetchPlayerBackup } from './fetchBackup';
+import { loadAndSyncBackup, captureReconciliationTargets } from './utils';
+import { useActionsStore } from '@/stores/actions';
+import type { PlanData } from '@/lib/storage/db';
+
+export async function initReconcile(
+  playerId: string,
+  plan: PlanData,
+  broadcastPresence?: (planId: string) => void
+): Promise<void> {
+  // 1. Clean slate
+  await resetAllStores();
+
+  // 2. Fetch backup for live comparison data
+  const { backup } = await fetchPlayerBackup(playerId);
+
+  // 3. Load backup into initialStateStore and temporarily populate global stores
+  //    (mode='reconcile' → loadAndSyncBackup handles Virtue/FuelTank but NOT TruthEggs)
+  loadAndSyncBackup(playerId, backup, 'reconcile');
+
+  // 4. Capture live comparison targets BEFORE the plan import overwrites stores
+  captureReconciliationTargets();
+
+  // 5. Set reconciliation mode
+  const actionsStore = useActionsStore();
+  actionsStore.isReconciling = true;
+  actionsStore.showIncompleteOnly = true;
+
+  // 6. Broadcast presence immediately to block other tabs
+  if (broadcastPresence) {
+    broadcastPresence(plan.id);
+  }
+
+  // 7. Load the plan from library — this overwrites stores with plan data
+  //    (importPlanLogic → hydrate overwrites initialStateStore, virtue, fuelTank, truthEggs, notes)
+  await actionsStore.loadPlanFromLibrary(plan);
+}

--- a/wasmegg/ascension-planner/src/lib/modes/reset.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/reset.ts
@@ -1,0 +1,79 @@
+/**
+ * @module resetAllStores
+ * @description Resets ALL Pinia stores to their known-zero default state.
+ *
+ * Every mode initializer calls this as its first step to guarantee a clean
+ * baseline. This eliminates cross-mode state leakage — the #1 source of
+ * mode-specific bugs.
+ *
+ * After this function returns, every store is at its Pinia default:
+ * - actionsStore: single start_ascension action (curiosity, no farm, no quick continue)
+ * - initialStateStore: hasData=false, no backup, no farm state
+ * - virtueStore: curiosity, 0 shifts, 0 TE, date=today, bank=0
+ * - commonResearchStore: all research at level 0
+ * - habCapacityStore: [hab_0, null, null, null]
+ * - shippingCapacityStore: [{vehicleId: 0, trainLength: 1}]
+ * - silosStore: siloCount=1
+ * - fuelTankStore: tankLevel=0, all fuel amounts=0
+ * - truthEggsStore: all eggsDelivered=0, all teEarned=0
+ * - salesStore: no sales active, no earnings boost
+ * - notesStore: empty notes array
+ *
+ * NOT reset (intentionally):
+ * - eventsStore: holds game calendar data, not per-session state
+ */
+
+import { useActionsStore } from '@/stores/actions';
+import { useInitialStateStore } from '@/stores/initialState';
+import { useVirtueStore } from '@/stores/virtue';
+import { useFuelTankStore } from '@/stores/fuelTank';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useCommonResearchStore } from '@/stores/commonResearch';
+import { useHabCapacityStore } from '@/stores/habCapacity';
+import { useShippingCapacityStore } from '@/stores/shippingCapacity';
+import { useSilosStore } from '@/stores/silos';
+import { useSalesStore } from '@/stores/sales';
+import { useNotesStore } from '@/stores/notes';
+
+/**
+ * Reset all stores to their default state.
+ *
+ * The order matters:
+ * 1. Clear the start action payload FIRST (before clearAll preserves it)
+ * 2. Clear actions store flags that clearAll doesn't touch (showIncompleteOnly)
+ * 3. Call clearAll (which resets isReconciling, reconcile*, activePlanId, editingGroupId)
+ * 4. Reset all other stores to Pinia defaults
+ *
+ * Recalculation is SKIPPED — the caller (mode initializer) will compute and
+ * set the initial snapshot after populating stores for its specific mode.
+ */
+export async function resetAllStores(): Promise<void> {
+  const actionsStore = useActionsStore();
+
+  // 1. Clean the start action payload before clearAll preserves it
+  const startAction = actionsStore.getStartAction();
+  if (startAction) {
+    startAction.payload.initialFarmState = undefined;
+    startAction.payload.isQuickContinue = false;
+    startAction.payload.initialEgg = 'curiosity';
+  }
+
+  // 2. Clear flags that clearAll() does NOT touch
+  actionsStore.showIncompleteOnly = false;
+
+  // 3. Clear actions (preserves the cleaned start action, resets reconcile state)
+  //    skipRecalculate=true because we haven't set up stores yet
+  await actionsStore.clearAll(undefined, true);
+
+  // 4. Reset every store to Pinia defaults
+  useInitialStateStore().$reset();
+  useVirtueStore().$reset();
+  useFuelTankStore().$reset();
+  useTruthEggsStore().$reset();
+  useCommonResearchStore().$reset();
+  useHabCapacityStore().$reset();
+  useShippingCapacityStore().$reset();
+  useSilosStore().$reset();
+  useSalesStore().$reset();
+  useNotesStore().$reset();
+}

--- a/wasmegg/ascension-planner/src/lib/modes/startFromScratch.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/startFromScratch.ts
@@ -1,0 +1,30 @@
+/**
+ * @module initStartFromScratch
+ * @description Mode A: Start from Scratch
+ *
+ * Contract:
+ * - No backup data loaded
+ * - All stores at defaults
+ * - Start action: egg=curiosity, no farm state, no quick continue
+ * - A "Wait for Full Habs" action is auto-added by setInitialSnapshot
+ */
+
+import { resetAllStores } from './reset';
+import { useActionsStore } from '@/stores/actions';
+import { computeSnapshot } from '@/engine/compute';
+import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
+
+export async function initStartFromScratch(): Promise<void> {
+  // 1. Clean slate — all stores to defaults
+  await resetAllStores();
+
+  // 2. Compute initial snapshot from default stores
+  //    (curiosity egg, no research, no farm state, population=0)
+  const context = getSimulationContext();
+  const baseState = createBaseEngineState(null);
+  const initialSnapshot = computeSnapshot(baseState, context);
+
+  // 3. Set initial snapshot (triggers recalculate + auto-adds Wait for Full Habs)
+  const actionsStore = useActionsStore();
+  await actionsStore.setInitialSnapshot(initialSnapshot);
+}

--- a/wasmegg/ascension-planner/src/lib/modes/utils.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/utils.ts
@@ -1,0 +1,165 @@
+import { useInitialStateStore } from '@/stores/initialState';
+import { useVirtueStore } from '@/stores/virtue';
+import { useFuelTankStore } from '@/stores/fuelTank';
+import { useTruthEggsStore } from '@/stores/truthEggs';
+import { useActionsStore } from '@/stores/actions';
+import { countTEThresholdsPassed } from '@/lib/truthEggs';
+import type { VirtueEgg, CalculationsSnapshot } from '@/types';
+import type { ei } from 'lib';
+
+/**
+ * Result of loading data from a backup.
+ */
+export interface BackupData {
+  initialShiftCount: number;
+  initialTE: number;
+  isUltra: boolean;
+  tankLevel: number;
+  virtueFuelAmounts: Record<VirtueEgg, number>;
+  eggsDelivered: Record<VirtueEgg, number>;
+  teEarnedPerEgg: Record<VirtueEgg, number>;
+}
+
+/**
+ * Loads a backup into the InitialState store and synchronizes global stores
+ * (Virtue, Fuel Tank, and optionally Truth Eggs) with the loaded data.
+ *
+ * @param playerId - Player ID
+ * @param backup - Raw protobuf backup
+ * @param mode - Loading mode
+ * @returns The parsed backup data
+ */
+export function loadAndSyncBackup(
+  playerId: string,
+  backup: ei.IBackup,
+  mode: 'plan_next' | 'continue_earnings' | 'continue_elr' | 'reconcile'
+): BackupData {
+  const initialStateStore = useInitialStateStore();
+  initialStateStore.rawBackup = backup;
+  const backupData = initialStateStore.loadFromBackup(playerId, backup, mode);
+
+  // 1. Sync Virtue Store
+  const virtueStore = useVirtueStore();
+  virtueStore.setInitialState(backupData.initialShiftCount, backupData.initialTE);
+
+  // 2. Sync Fuel Tank Store
+  const fuelTankStore = useFuelTankStore();
+  fuelTankStore.setTankLevel(backupData.tankLevel);
+  for (const [egg, amount] of Object.entries(backupData.virtueFuelAmounts)) {
+    fuelTankStore.setFuelAmount(egg as VirtueEgg, amount);
+  }
+
+  // 3. Sync Truth Eggs Store
+  // Note: Reconcile mode does NOT sync Truth Eggs store immediately because it
+  // wants to preserve the plan's truth egg state after loading.
+  if (mode !== 'reconcile') {
+    const truthEggsStore = useTruthEggsStore();
+    for (const [egg, delivered] of Object.entries(backupData.eggsDelivered)) {
+      truthEggsStore.setEggsDelivered(egg as VirtueEgg, delivered);
+    }
+    for (const [egg, earned] of Object.entries(backupData.teEarnedPerEgg)) {
+      truthEggsStore.setTEEarned(egg as VirtueEgg, earned);
+    }
+  }
+
+  return backupData;
+}
+
+/**
+ * Captures the current farm state and progress from InitialState store
+ * into the Actions store as reconciliation targets.
+ */
+export function captureReconciliationTargets() {
+  const initialStateStore = useInitialStateStore();
+  const actionsStore = useActionsStore();
+
+  if (initialStateStore.currentFarmState) {
+    actionsStore.reconcileFarmState = JSON.parse(JSON.stringify(initialStateStore.currentFarmState));
+  } else {
+    actionsStore.reconcileFarmState = null;
+  }
+  actionsStore.reconcileEggsDelivered = JSON.parse(JSON.stringify(initialStateStore.initialEggsDelivered));
+  actionsStore.reconcileTeEarned = JSON.parse(JSON.stringify(initialStateStore.initialTeEarned));
+}
+
+/**
+ * Updates the current farm state and initial eggs delivered based on a catch-up snapshot
+ * computed from a backup (which might be several hours old).
+ *
+ * @param snapshot - The catch-up snapshot
+ * @param baseBankValue - Bank value at the start of catch-up
+ * @param ascensionStartTime - Timestamp when the ascension (catch-up) begins
+ * @param teEarnedPerEgg - Optional: Map of TE earned per egg to update pending TE calculation
+ */
+export function catchUpFarmState(
+  snapshot: CalculationsSnapshot,
+  baseBankValue: number,
+  ascensionStartTime: number,
+  teEarnedPerEgg?: Record<string, number>
+) {
+  const initialStateStore = useInitialStateStore();
+  const truthEggsStore = useTruthEggsStore();
+
+  // 1. Sync eggs delivered to TruthEggsStore
+  for (const [egg, amount] of Object.entries(snapshot.eggsDelivered)) {
+    truthEggsStore.setEggsDelivered(egg as VirtueEgg, amount);
+  }
+
+  // 2. Sync TE earned to TruthEggsStore if provided
+  if (teEarnedPerEgg) {
+    for (const [egg, count] of Object.entries(teEarnedPerEgg)) {
+      truthEggsStore.setTEEarned(egg as VirtueEgg, count);
+    }
+  }
+
+  // 3. Update farm state if it exists
+  if (initialStateStore.currentFarmState) {
+    const farm = initialStateStore.currentFarmState;
+    const egg = snapshot.currentEgg;
+    const newDelivered = snapshot.eggsDelivered[egg] || 0;
+    const extraCash = snapshot.bankValue - baseBankValue;
+
+    farm.population = snapshot.population;
+    farm.cash = snapshot.bankValue;
+    farm.cashEarned += Math.max(0, extraCash);
+    farm.deliveredEggs = newDelivered;
+    farm.lastStepTime = ascensionStartTime;
+
+    initialStateStore.setInitialEggsDelivered(egg, newDelivered);
+
+    // If TE map provided, also update pending TE
+    if (teEarnedPerEgg) {
+      const theoreticalTE = countTEThresholdsPassed(newDelivered);
+      const earned = teEarnedPerEgg[egg] || 0;
+      initialStateStore.setInitialTePending(egg, Math.max(0, theoreticalTE - earned));
+    }
+  }
+}
+
+/**
+ * Rolls up all pending Truth Eggs into earned Truth Eggs and synchronizes
+ * the InitialState, TruthEggs, and Virtue stores. Used when starting a new plan.
+ */
+export function rollUpPendingTE() {
+  const initialStateStore = useInitialStateStore();
+  const truthEggsStore = useTruthEggsStore();
+  const virtueStore = useVirtueStore();
+
+  for (const egg of Object.keys(initialStateStore.initialTePending) as VirtueEgg[]) {
+    const pending = initialStateStore.initialTePending[egg];
+    if (pending > 0) {
+      const currentEarned = initialStateStore.initialTeEarned[egg];
+      const newTotal = Math.min(98, currentEarned + pending);
+      truthEggsStore.setTEEarned(egg, newTotal);
+      initialStateStore.setInitialTePending(egg, 0);
+    }
+  }
+
+  // Sync rolled-up TE back to initialState
+  for (const egg of Object.keys(initialStateStore.initialTeEarned) as VirtueEgg[]) {
+    initialStateStore.setInitialEggsDelivered(egg, truthEggsStore.eggsDelivered[egg]);
+    initialStateStore.setInitialTeEarned(egg, truthEggsStore.teEarned[egg]);
+  }
+  virtueStore.setTE(truthEggsStore.totalTE);
+  virtueStore.setInitialTE(truthEggsStore.totalTE);
+}

--- a/wasmegg/ascension-planner/src/lib/modes/utils.ts
+++ b/wasmegg/ascension-planner/src/lib/modes/utils.ts
@@ -32,7 +32,7 @@ export interface BackupData {
 export function loadAndSyncBackup(
   playerId: string,
   backup: ei.IBackup,
-  mode: 'plan_next' | 'continue_earnings' | 'continue_elr' | 'reconcile'
+  mode: 'scratch' | 'plan_next' | 'continue_earnings' | 'continue_elr' | 'reconcile' | 'default'
 ): BackupData {
   const initialStateStore = useInitialStateStore();
   initialStateStore.rawBackup = backup;

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -113,6 +113,11 @@ export const useActionsStore = defineStore('actions', {
       return startAction.endState.lastStepTime || 0;
     },
 
+    ascensionStartTime(): number {
+      const vStore = useVirtueStore();
+      return vStore.planStartTime.getTime() / 1000;
+    },
+
     getActionReconciliationStatus() {
       return (action: Action): 'completed' | 'pending' | 'na' => {
         if (!this.isReconciling) return 'na';

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -55,7 +55,7 @@ export const useActionsStore = defineStore('actions', {
       reconcileTeEarned: null,
       showIncompleteOnly: true,
       activePlanId: null,
-      lastSavedActionsJson: '[]',
+      lastSavedActionsJson: JSON.stringify([startAction]),
       libraryUpdateTick: 0,
       manualOverrides: JSON.parse(localStorage.getItem('ascension_manual_overrides') || '{}') as Record<string, Record<string, boolean>>,
     };
@@ -151,8 +151,34 @@ export const useActionsStore = defineStore('actions', {
     },
 
     isDirty(): boolean {
-      const currentActionsJson = JSON.stringify(this.actions);
-      return currentActionsJson !== this.lastSavedActionsJson;
+      const isTrivial = (a: Action): boolean => {
+        if (a.type === 'shift') return true;
+        if (a.type === 'wait_for_full_habs') return true;
+        if (a.type === 'toggle_earnings_boost' && (a.payload as any).active) return true;
+        if (a.type === 'toggle_sale' && (a.payload as any).active) return true;
+        return false;
+      };
+
+      const summarize = (actions: Action[]) => {
+        return actions
+          .filter(a => !isTrivial(a))
+          .map(a => ({
+            type: a.type,
+            payload: a.payload,
+          }));
+      };
+
+      const currentSummary = JSON.stringify(summarize(this.actions));
+      
+      let savedActions: Action[] = [];
+      try {
+        savedActions = JSON.parse(this.lastSavedActionsJson);
+      } catch (e) {
+        return true;
+      }
+      const savedSummary = JSON.stringify(summarize(savedActions));
+
+      return currentSummary !== savedSummary;
     },
   },
 

--- a/wasmegg/ascension-planner/src/stores/actions/index.ts
+++ b/wasmegg/ascension-planner/src/stores/actions/index.ts
@@ -204,6 +204,7 @@ export const useActionsStore = defineStore('actions', {
       }
 
       await this.recalculateFrom(0);
+      this.lastSavedActionsJson = JSON.stringify(this.actions);
     },
 
     pushWaitForFullHabsAction() {


### PR DESCRIPTION
This adds a new Wait action to allow a user to plan out the end of their ascension quickly and easily, in a single step.

Minor Fixes:

Fuel Tank Level wasn't pulling from user data
Event expiration warnings now allow an overlap of 1 second. They were triggering for a few milliseconds of overlap.