### PR TITLE
Add button to pull backup when needed on Research > ELR Impact > Realistic

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -307,7 +307,10 @@
             </button>
           </div>
           <div v-if="expandedSections.availableActions" class="border-t border-gray-200 p-4 bg-gray-50 rounded-b-lg">
-            <AvailableActions @show-current-details="showCurrentDetails" />
+            <AvailableActions 
+              @show-current-details="showCurrentDetails" 
+              @refresh-backup="handleRefreshReconcile"
+            />
           </div>
         </div>
       </div>

--- a/wasmegg/ascension-planner/src/components/AvailableActions.vue
+++ b/wasmegg/ascension-planner/src/components/AvailableActions.vue
@@ -63,7 +63,7 @@
       <InitialStateContainer v-if="activeTab === 'initial'" />
       <VehicleActions v-if="activeTab === 'vehicles'" />
       <HabActions v-if="activeTab === 'habs'" />
-      <ResearchActions v-if="activeTab === 'research'" />
+      <ResearchActions v-if="activeTab === 'research'" @refresh-backup="$emit('refresh-backup')" />
       <ShiftActions v-if="activeTab === 'shift'" />
       <ArtifactActions v-if="activeTab === 'artifacts'" />
       <SiloActions v-if="activeTab === 'silos'" />
@@ -114,6 +114,7 @@ onUnmounted(() => {
 
 defineEmits<{
   'show-current-details': [];
+  'refresh-backup': [];
 }>();
 
 // Check if any shifts have been made

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -81,6 +81,7 @@
       @buy="handleBuyResearch"
       @max="handleMaxResearch"
       @buy-to-here="handleBuyToHere"
+      @refresh-backup="$emit('refresh-backup')"
     />
 
     <EventExpiryDialog

--- a/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchFlatView.vue
@@ -48,14 +48,31 @@
     </template>
 
     <div v-if="sortedResearches.length === 0" class="px-4 py-8 text-center text-gray-500 italic bg-gray-50">
-      No researches match this criteria or all are maxed.
+      <div v-if="isMissingRealisticData" class="max-w-xs mx-auto">
+        <p class="text-gray-900 font-bold not-italic mb-1 text-sm">Artifact Data Required</p>
+        <p class="text-[11px] leading-relaxed mb-4 not-italic">
+          Realistic predictions require your artifact inventory. We omit this data from saved plans for privacy when sharing files.
+          Click below to refresh your local data and enable the realistic view for this session.
+        </p>
+        <button
+          class="btn-premium btn-primary w-full mt-2"
+          @click="$emit('refresh-backup')"
+        >
+          Refresh & Fix Plan
+        </button>
+      </div>
+      <template v-else>
+        No researches match this criteria or all are maxed.
+      </template>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import { type CommonResearch } from '@/calculations/commonResearch';
 import { type ViewType } from '@/composables/useResearchViews';
+import { useInitialStateStore } from '@/stores/initialState';
 import ResearchItem from './ResearchItem.vue';
 
 interface SortedResearchItem {
@@ -83,7 +100,7 @@ interface SortedResearchItem {
   showDeadlineWarning?: boolean;
 }
 
-defineProps<{
+const props = defineProps<{
   sortedResearches: SortedResearchItem[];
   view: ViewType;
   thresholds: readonly number[];
@@ -91,5 +108,8 @@ defineProps<{
   getResearchTimeToBuySeconds: (r: CommonResearch) => number;
 }>();
 
-defineEmits(['buy', 'max', 'buy-to-here']);
+const initialStateStore = useInitialStateStore();
+const isMissingRealisticData = computed(() => props.view === 'elr' && !initialStateStore.rawBackup);
+
+defineEmits(['buy', 'max', 'buy-to-here', 'refresh-backup']);
 </script>

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -788,7 +788,8 @@ export function useResearchViews() {
               },
               showDeadlineWarning: isSale && (absoluteSimTime + secondsToBuyWithBank > researchSaleDeadline.value),
             };
-          });
+          })
+          .filter(c => c.impact > 0);
       } else {
         // Potential mode: theoretical formula-based impact
         const currentSlots = calculateMaxVehicleSlots(researchLevels);

--- a/wasmegg/ascension-planner/src/stores/initialState.ts
+++ b/wasmegg/ascension-planner/src/stores/initialState.ts
@@ -515,6 +515,9 @@ export const useInitialStateStore = defineStore('initialState', {
       if (data.activeMissions) {
         this.activeMissions = [...data.activeMissions];
       }
+      if (data.rawBackup) {
+        this.rawBackup = data.rawBackup;
+      }
 
       // Sync Truth Eggs Store
       const truthEggsStore = useTruthEggsStore();


### PR DESCRIPTION
give users a way to get their artifacts populated when loading a saved plan. Having no artifacts from their backup was causing the "realistic" view of ELR impact on research to show no researches.