### PR TITLE
various fixes and upgrades

### DIFF
--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -409,7 +409,7 @@
         </div>
         <div class="px-6 py-4 bg-slate-50 flex justify-end gap-3 rounded-b-2xl">
           <button class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm" @click="handleArtifactSetSelection('elr')">
-            ELR Set
+            Delivery Rate Set
           </button>
           <button class="px-4 py-2 text-sm font-semibold text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 transition-colors shadow-sm" @click="handleArtifactSetSelection('earnings')">
             Earnings Set

--- a/wasmegg/ascension-planner/src/App.vue
+++ b/wasmegg/ascension-planner/src/App.vue
@@ -210,6 +210,11 @@
         </button>
       </div>
 
+      <!-- Current Mode Label -->
+      <div v-if="plannerTab === 'manual' && plannerModeLabel" class="mt-4 flex justify-center">
+        <span class="text-sm font-bold text-slate-700">{{ plannerModeLabel }}</span>
+      </div>
+
       <!-- Reconciliation Status Banner -->
       <div v-if="actionsStore.isReconciling" class="mt-4 flex flex-col items-center gap-2">
         <div
@@ -644,7 +649,22 @@ const expandedSections = ref({
 
 // isHeaderCollapsed moved to UI store
 
-function handlePlanLoaded() {
+type PlannerMode = 'scratch' | 'future' | 'continue' | 'library' | 'reconcile' | null;
+const plannerMode = ref<PlannerMode>(null);
+const loadedPlanName = ref('');
+
+const plannerModeLabel = computed(() => {
+  if (plannerMode.value === 'scratch') return 'Start from Scratch';
+  if (plannerMode.value === 'future') return 'Plan Future Ascension';
+  if (plannerMode.value === 'continue') return 'Continue Current Ascension';
+  if (plannerMode.value === 'library') return loadedPlanName.value;
+  if (plannerMode.value === 'reconcile') return `Reconciling ${loadedPlanName.value}`;
+  return null;
+});
+
+function handlePlanLoaded(name: string) {
+  plannerMode.value = 'library';
+  loadedPlanName.value = name;
   plannerTab.value = 'manual';
   isHeaderCollapsed.value = true;
   scrollToTop();
@@ -756,6 +776,7 @@ function executeClearAll() {
 async function startFromScratch() {
   error.value = '';
   try {
+    plannerMode.value = 'scratch';
     plannerTab.value = 'manual';
     await initStartFromScratch();
     isHeaderCollapsed.value = true;
@@ -779,6 +800,8 @@ async function handleLibraryReconcile(plan: import('@/lib/storage/db').PlanData)
   error.value = '';
 
   try {
+    plannerMode.value = 'reconcile';
+    loadedPlanName.value = plan.name;
     plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initReconcile(playerId.value, plan, broadcastPresence);
@@ -984,6 +1007,7 @@ async function quickContinueAscension(selection: 'earnings' | 'elr') {
   loading.value = true;
 
   try {
+    plannerMode.value = 'continue';
     plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initContinueCurrent(playerId.value, selection);
@@ -1007,6 +1031,7 @@ async function planNextAscension() {
   loading.value = true;
 
   try {
+    plannerMode.value = 'future';
     plannerTab.value = 'manual';
     savePlayerID(playerId.value);
     await initPlanFuture(playerId.value);

--- a/wasmegg/ascension-planner/src/auto/ascension.ts
+++ b/wasmegg/ascension-planner/src/auto/ascension.ts
@@ -370,11 +370,12 @@ export function runContinueCurrent(
 ): { actions: Action[]; summary: AscensionSummary } {
   const actualStartState: EngineState = JSON.parse(JSON.stringify(startState));
 
-  // Catch-up earnings: determine how long ago the last backup was,
-  // then add that many eggs based on current ELR.
-  const approxTime = context.rawBackup?.approxTime || 0;
-  if (approxTime > 0 && startTime > approxTime) {
-    const elapsedSeconds = startTime - approxTime;
+  // Catch-up: add eggs laid since the farm's last sync (lastStepTime) up to the plan
+  // start, assuming a constant lay rate. Mirrors the guard in computeSnapshot —
+  // lastStepTime > 1e9 distinguishes a real Unix timestamp from a 0-based sim offset.
+  const lastSyncTime = actualStartState.lastStepTime;
+  if (lastSyncTime > 1e9 && startTime > lastSyncTime) {
+    const elapsedSeconds = startTime - lastSyncTime;
     const catchUpEggs = currentELR * elapsedSeconds;
     const currentEgg = actualStartState.currentEgg;
     actualStartState.eggsDelivered[currentEgg] = (actualStartState.eggsDelivered[currentEgg] || 0) + catchUpEggs;

--- a/wasmegg/ascension-planner/src/auto/ascension.ts
+++ b/wasmegg/ascension-planner/src/auto/ascension.ts
@@ -1,6 +1,7 @@
 import { type Action, generateActionId } from '@/types/actions/meta';
 import { computeSnapshot } from '@/engine/compute';
-import { countTEThresholdsPassed } from '@/lib/truthEggs';
+import { countTEThresholdsPassed, getThresholdForTE } from '@/lib/truthEggs';
+import { timeToEarnTE } from './te-thresholds';
 import { computeShiftCosts } from './se-tracker';
 import { calculateEggsLaidDuringActions } from './engine/eggs';
 import type { EngineState, SimulationContext, AscensionSummary, ShiftResult } from './types';
@@ -18,6 +19,13 @@ import { getNextSaleStart, getNextSaleEnd, isResearchSaleActive, isEarningsBoost
 import { calculateArtifactModifiers } from '@/lib/artifacts';
 import { computeRealisticELR } from '@/calculations/realisticELR';
 import type { VirtueEgg } from '@/types';
+
+function computeLastTEDuration(finalTE: Record<VirtueEgg, number>, peakELR: number): number {
+  const maxTE = Math.max(...Object.values(finalTE));
+  if (maxTE <= 0 || peakELR <= 0) return 0;
+  const prevEggs = maxTE > 1 ? getThresholdForTE(maxTE - 1) : 0;
+  return timeToEarnTE(prevEggs, peakELR, 1);
+}
 
 /**
  * Derives the starting state for the next ascension in a sequential chain.
@@ -325,6 +333,13 @@ export function runAscension(
     },
     strategyLabel: `${saleCount}-sale build`,
     isMaxELRAscension: false,
+    lastTEDurationSeconds: computeLastTEDuration({
+      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+    }, currentState.maxELR || 0),
   };
 
   return {
@@ -480,6 +495,13 @@ export function runContinueCurrent(
     },
     strategyLabel: 'Continue current',
     isMaxELRAscension: false,
+    lastTEDurationSeconds: computeLastTEDuration({
+      curiosity: countTEThresholdsPassed(currentState.eggsDelivered['curiosity'] || 0),
+      integrity: countTEThresholdsPassed(currentState.eggsDelivered['integrity'] || 0),
+      resilience: countTEThresholdsPassed(currentState.eggsDelivered['resilience'] || 0),
+      humility: countTEThresholdsPassed(currentState.eggsDelivered['humility'] || 0),
+      kindness: countTEThresholdsPassed(currentState.eggsDelivered['kindness'] || 0),
+    }, currentELR),
   };
 
   return {

--- a/wasmegg/ascension-planner/src/auto/types.ts
+++ b/wasmegg/ascension-planner/src/auto/types.ts
@@ -33,6 +33,9 @@ export interface AscensionSummary {
   teEarned: Record<VirtueEgg, number>;    // Gained during this ascension
   finalTE: Record<VirtueEgg, number>;     // Total after ascension
   
+  // Time to earn the final TE step of the highest-TE egg
+  lastTEDurationSeconds: number;
+
   // Strategy label for display
   strategyLabel: string;                  // e.g., "1-sale build, 20 TE"
   

--- a/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
+++ b/wasmegg/ascension-planner/src/components/ActionHistoryItem.vue
@@ -124,7 +124,7 @@
           <span v-if="action.ihrDelta" :class="deltaClass(action.ihrDelta)">IHR {{ formatDelta(action.ihrDelta) }}</span>
           <span v-if="action.layRateDelta" :class="deltaClass(action.layRateDelta)">Lay {{ formatDelta(action.layRateDelta) }}</span>
           <span v-if="action.shippingCapacityDelta" :class="deltaClass(action.shippingCapacityDelta)">Ship {{ formatDelta(action.shippingCapacityDelta) }}</span>
-          <span v-if="action.elrDelta" :class="deltaClass(action.elrDelta)">ELR {{ formatDelta(action.elrDelta) }}</span>
+          <span v-if="action.elrDelta" :class="deltaClass(action.elrDelta)">Delivery {{ formatDelta(action.elrDelta) }}</span>
           <span v-if="action.offlineEarningsDelta" :class="deltaClass(action.offlineEarningsDelta)">Earn {{ formatDelta(action.offlineEarningsDelta) }}</span>
           <span v-if="action.populationDelta" :class="deltaClass(action.populationDelta)">Pop {{ formatDelta(action.populationDelta) }}</span>
           <span

--- a/wasmegg/ascension-planner/src/components/CalculationSummary.vue
+++ b/wasmegg/ascension-planner/src/components/CalculationSummary.vue
@@ -151,7 +151,7 @@
         @click="toggleSection('elr')"
       >
         <div class="flex flex-col">
-          <span class="text-xs font-bold text-slate-700 uppercase tracking-tight">Effective Lay Rate</span>
+          <span class="text-xs font-bold text-slate-700 uppercase tracking-tight">Delivery Rate</span>
           <span class="text-[9px] text-slate-400 font-black uppercase tracking-widest">Actual Deliveries</span>
         </div>
         <div class="flex items-center gap-4">

--- a/wasmegg/ascension-planner/src/components/FloatingStats.vue
+++ b/wasmegg/ascension-planner/src/components/FloatingStats.vue
@@ -45,7 +45,7 @@
     <div v-if="!isCollapsed" class="flex flex-col items-center w-full transition-all">
       <!-- Active Set Badge -->
       <div v-if="activeSet" class="badge-premium badge-brand py-0.5 mb-3 scale-90">
-        {{ activeSet === 'earnings' ? 'Earnings' : 'ELR' }} Set
+        {{ activeSet === 'earnings' ? 'Earnings' : 'Delivery Rate' }} Set
       </div>
       <div v-else class="badge-premium py-0.5 mb-3 scale-90 bg-slate-100 text-slate-500">No Active Set</div>
 
@@ -109,7 +109,7 @@
 
         <!-- ELR -->
         <div class="flex flex-col items-center">
-          <span class="text-[9px] font-black text-slate-400 uppercase tracking-widest">ELR</span>
+          <span class="text-[9px] font-black text-slate-400 uppercase tracking-widest">Delivery</span>
           <span class="font-mono-premium text-[11px] font-bold text-slate-700">
             {{ formatRate(elrHr) }}
           </span>

--- a/wasmegg/ascension-planner/src/components/PlanFinalSummary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanFinalSummary.vue
@@ -318,14 +318,18 @@ const teStatsList = computed(() => {
 
 function formatDateTime(date: Date): string {
   if (isNaN(date.getTime())) return 'N/A';
-  return date.toLocaleString('en-US', {
+  const options: Intl.DateTimeFormatOptions = {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
     hour12: true,
-  });
+  };
+  if (date.getFullYear() !== new Date().getFullYear()) {
+    options.year = 'numeric';
+  }
+  return date.toLocaleString('en-US', options);
 }
 
 // Import/Export Logic

--- a/wasmegg/ascension-planner/src/components/PlanLibrary.vue
+++ b/wasmegg/ascension-planner/src/components/PlanLibrary.vue
@@ -84,7 +84,7 @@ async function loadPlan(plan: PlanData) {
   try {
     broadcastPresence(plan.id); // Immediate heartbeat to block other tabs
     await initLoadPlan(plan);
-    emit('plan-loaded');
+    emit('plan-loaded', plan.name);
   } catch (err) {
     console.error('[PlanLibrary] Error loading plan:', err);
     alert('Failed to load plan: ' + err);
@@ -518,7 +518,7 @@ function handleAutoPlanCancel() {
   }
 }
 
-const emit = defineEmits(['plan-loaded']);
+const emit = defineEmits<{ 'plan-loaded': [name: string] }>();
 </script>
 
 <template>

--- a/wasmegg/ascension-planner/src/components/actions/ArtifactActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ArtifactActions.vue
@@ -102,7 +102,7 @@
             class="px-3 py-1 text-white text-[10px] font-black uppercase tracking-widest rounded-lg shadow-sm transition-colors flex items-center gap-1.5"
             :class="isOptimalELR ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-amber-600 hover:bg-amber-700'"
             @click="equipOptimalELR"
-            v-tippy="'Find and equip the best ELR set from your inventory'"
+            v-tippy="'Find and equip the best delivery rate set from your inventory'"
           >
             <svg class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
               <path
@@ -111,7 +111,7 @@
                 clip-rule="evenodd"
               />
             </svg>
-            Optimal ELR
+            Optimal Delivery Rate
           </button>
         </div>
       </div>
@@ -139,7 +139,7 @@
             <p class="text-[10px] text-blue-700 leading-tight">
               <strong>Earnings:</strong> Necklaces, Ankhs, Cubes, Lunar stones.
               <br />
-              <strong>ELR:</strong> Metronomes, Compasses, Tachyon/Quantum stones.
+              <strong>Delivery:</strong> Metronomes, Compasses, Tachyon/Quantum stones.
             </p>
           </div>
         </div>

--- a/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/BulkWaitForTEActions.vue
@@ -11,7 +11,8 @@
           >
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" /></svg>
           </button>
-          <input 
+          <input
+            ref="inputEl"
             type="number"
             v-model.number="totalTEToGain"
             class="w-16 bg-white border border-slate-200 rounded-lg px-2 py-1 text-center font-mono-premium font-bold text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-900/5 transition-all shadow-sm"
@@ -145,6 +146,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
+const inputEl = ref<HTMLInputElement | null>(null);
+defineExpose({ focus: () => inputEl.value?.focus() });
 import { iconURL, shiftCost } from 'lib';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useVirtueStore } from '@/stores/virtue';

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -14,6 +14,20 @@
       {{ viewDescription }}
     </p>
 
+    <div v-if="currentView === 'roi'" class="flex items-center justify-between px-1 mb-2">
+      <span class="text-xs text-gray-500">Delivery Impact Only</span>
+      <button
+        @click="deliveryImpactOnly = !deliveryImpactOnly"
+        class="relative inline-flex h-5 w-10 items-center rounded-full transition-all duration-300 focus:outline-none shadow-inner"
+        :class="deliveryImpactOnly ? 'bg-indigo-500' : 'bg-slate-200'"
+      >
+        <span
+          class="inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-all duration-300 shadow-sm"
+          :class="deliveryImpactOnly ? 'translate-x-[22px]' : 'translate-x-1'"
+        />
+      </button>
+    </div>
+
     <ElrViewControls
       v-if="currentView === 'elr'"
       :view-mode="elrViewMode"
@@ -144,6 +158,7 @@ const {
   currentView,
   elrViewMode,
   elrSortMode,
+  deliveryImpactOnly,
   viewDescription,
   costModifiers,
   isResearchSaleActive,

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -14,18 +14,45 @@
       {{ viewDescription }}
     </p>
 
-    <div v-if="currentView === 'roi'" class="flex items-center justify-between px-1 mb-2">
-      <span class="text-xs text-gray-500">Delivery Impact Only</span>
-      <button
-        @click="deliveryImpactOnly = !deliveryImpactOnly"
-        class="relative inline-flex h-5 w-10 items-center rounded-full transition-all duration-300 focus:outline-none shadow-inner"
-        :class="deliveryImpactOnly ? 'bg-indigo-500' : 'bg-slate-200'"
-      >
-        <span
-          class="inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-all duration-300 shadow-sm"
-          :class="deliveryImpactOnly ? 'translate-x-[22px]' : 'translate-x-1'"
-        />
-      </button>
+    <div v-if="currentView === 'roi'" class="px-1 mb-2 space-y-2">
+      <div class="flex items-center justify-between">
+        <span class="text-xs text-gray-500">Delivery Impact Only</span>
+        <button
+          @click="deliveryImpactOnly = !deliveryImpactOnly"
+          class="relative inline-flex h-5 w-10 items-center rounded-full transition-all duration-300 focus:outline-none shadow-inner"
+          :class="deliveryImpactOnly ? 'bg-indigo-500' : 'bg-slate-200'"
+        >
+          <span
+            class="inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-all duration-300 shadow-sm"
+            :class="deliveryImpactOnly ? 'translate-x-[22px]' : 'translate-x-1'"
+          />
+        </button>
+      </div>
+      <div class="flex items-center justify-between">
+        <span class="text-xs text-gray-500">Achieve ROI</span>
+        <div class="flex items-center gap-1.5">
+          <div class="flex gap-0.5 p-0.5 bg-gray-100 rounded-md shadow-inner">
+            <button
+              @click="roiMode = 'immediate'"
+              class="px-2 py-0.5 text-[10px] font-medium rounded transition-all whitespace-nowrap"
+              :class="roiMode === 'immediate' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'"
+            >
+              Immediate Impact
+            </button>
+            <button
+              @click="roiMode = 'maxed_vehicles'"
+              class="px-2 py-0.5 text-[10px] font-medium rounded transition-all whitespace-nowrap"
+              :class="roiMode === 'maxed_vehicles' ? 'bg-white text-blue-600 shadow-sm' : 'text-gray-500 hover:text-gray-700 hover:bg-gray-200'"
+            >
+              Max Vehicles
+            </button>
+          </div>
+          <span
+            class="w-4 h-4 inline-flex items-center justify-center rounded-full bg-gray-100 text-gray-400 text-[9px] cursor-help hover:bg-gray-200 transition-colors leading-none shrink-0"
+            v-tippy="'Max Vehicles mode calculates Achieve ROI as if you had gone to Kindness and bought all available vehicles and hyperloop cars — after buying the research in question.'"
+          >?</span>
+        </div>
+      </div>
     </div>
 
     <ElrViewControls
@@ -159,6 +186,7 @@ const {
   elrViewMode,
   elrSortMode,
   deliveryImpactOnly,
+  roiMode,
   viewDescription,
   costModifiers,
   isResearchSaleActive,

--- a/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchActions.vue
@@ -41,7 +41,7 @@
           </span>
         </div>
         <div class="flex flex-col border-l border-gray-200 pl-6">
-          <span class="text-[10px] font-bold text-gray-500 uppercase tracking-wider leading-none mb-1">ELR</span>
+          <span class="text-[10px] font-bold text-gray-500 uppercase tracking-wider leading-none mb-1">Delivery Rate</span>
           <span class="text-sm font-mono font-bold text-gray-900 leading-none py-1" v-tippy="'The lower of the two rates'">
             {{ formatNumber(realisticSummary.elr) }}/hr
           </span>

--- a/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ResearchItem.vue
@@ -49,7 +49,7 @@
             </svg>
             <span>
               <span class="font-bold uppercase tracking-tight mr-1">Lookahead:</span>
-              Needs {{ lookahead.minLevels }} levels for +{{ (lookahead.impact * 100).toFixed(3) }}% ELR ({{ lookahead.hpp.toFixed(1) }} hr/%)
+              Needs {{ lookahead.minLevels }} levels for +{{ (lookahead.impact * 100).toFixed(3) }}% Delivery Rate ({{ lookahead.hpp.toFixed(1) }} hr/%)
             </span>
           </div>
         </div>
@@ -199,7 +199,7 @@
          </div>
        </div>
        <div class="text-right">
-         <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter leading-none mb-1 block text-right font-mono">ELR</span>
+         <span class="text-[8px] font-bold text-gray-400 uppercase tracking-tighter leading-none mb-1 block text-right font-mono">Delivery Rate</span>
          <div class="flex items-center justify-end gap-1 leading-none">
            <span class="text-[11px] font-mono font-bold text-gray-900">
              {{ formatNumber(realisticStats.elr) }}/hr

--- a/wasmegg/ascension-planner/src/components/actions/ShiftActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/ShiftActions.vue
@@ -69,6 +69,13 @@
             </span>
             <img :src="iconURL('egginc/egg_soul.png', 32)" class="w-3.5 h-3.5" alt="SE" />
           </div>
+          <span
+            class="text-[10px] font-bold uppercase tracking-tight"
+            :class="shiftsUntilBroke <= 2 ? 'text-red-500' : 'text-slate-400'"
+            v-tippy="'Shifts remaining before SE goes negative'"
+          >
+            {{ shiftsUntilBroke }} left
+          </span>
         </div>
       </div>
 
@@ -230,6 +237,20 @@ const nextShiftCostValue = computed(() => {
 
 const isAffordable = computed(() => {
   return actionsStore.effectiveSnapshot.soulEggs >= nextShiftCostValue.value;
+});
+
+const shiftsUntilBroke = computed(() => {
+  let se = actionsStore.effectiveSnapshot.soulEggs;
+  let count = virtueStore.shiftCount;
+  let affordable = 0;
+  while (affordable <= 1000) {
+    const cost = shiftCost(se, count);
+    if (se < cost) break;
+    se -= cost;
+    count++;
+    affordable++;
+  }
+  return affordable;
 });
 
 function handleShift(toEgg: VirtueEgg) {

--- a/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitActions.vue
@@ -30,7 +30,7 @@
         </svg>
       </button>
       <div v-show="teExpanded" class="p-6 border-t border-slate-50">
-        <WaitForTEActions @show-current-details="$emit('show-current-details')" />
+        <WaitForTEActions ref="teActionsRef" @show-current-details="$emit('show-current-details')" />
       </div>
     </div>
 
@@ -61,7 +61,7 @@
         </svg>
       </button>
       <div v-show="bulkTEExpanded" class="p-6 border-t border-slate-50">
-        <BulkWaitForTEActions />
+        <BulkWaitForTEActions ref="bulkTEActionsRef" />
       </div>
     </div>
 
@@ -156,7 +156,7 @@
         </svg>
       </button>
       <div v-show="gemsExpanded" class="p-6 border-t border-slate-50">
-        <WaitForGemsActions />
+        <WaitForGemsActions ref="gemsActionsRef" />
       </div>
     </div>
 
@@ -187,7 +187,7 @@
         </svg>
       </button>
       <div v-show="timeExpanded" class="p-6 border-t border-slate-50">
-        <WaitForTimeActions />
+        <WaitForTimeActions ref="timeActionsRef" />
       </div>
     </div>
 
@@ -218,7 +218,7 @@
         </svg>
       </button>
       <div v-show="noEarningsExpanded" class="p-6 border-t border-slate-50">
-        <WaitWithoutEarningsActions />
+        <WaitWithoutEarningsActions ref="noEarningsActionsRef" />
       </div>
     </div>
 
@@ -263,7 +263,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import { iconURL } from 'lib';
 import { useActionsStore } from '@/stores/actions';
 import WaitForTEActions from './WaitForTEActions.vue';
@@ -288,6 +288,18 @@ const gemsExpanded = ref(false);
 const timeExpanded = ref(false);
 const noEarningsExpanded = ref(false);
 const eventsExpanded = ref(false);
+
+const teActionsRef = ref<InstanceType<typeof WaitForTEActions> | null>(null);
+const bulkTEActionsRef = ref<InstanceType<typeof BulkWaitForTEActions> | null>(null);
+const gemsActionsRef = ref<InstanceType<typeof WaitForGemsActions> | null>(null);
+const timeActionsRef = ref<InstanceType<typeof WaitForTimeActions> | null>(null);
+const noEarningsActionsRef = ref<InstanceType<typeof WaitWithoutEarningsActions> | null>(null);
+
+watch(teExpanded, val => { if (val) nextTick(() => teActionsRef.value?.focus()); });
+watch(bulkTEExpanded, val => { if (val) nextTick(() => bulkTEActionsRef.value?.focus()); });
+watch(gemsExpanded, val => { if (val) nextTick(() => gemsActionsRef.value?.focus()); });
+watch(timeExpanded, val => { if (val) nextTick(() => timeActionsRef.value?.focus()); });
+watch(noEarningsExpanded, val => { if (val) nextTick(() => noEarningsActionsRef.value?.focus()); });
 
 defineEmits<{
   'show-current-details': [];

--- a/wasmegg/ascension-planner/src/components/actions/WaitForGemsActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitForGemsActions.vue
@@ -36,6 +36,7 @@
       <div class="flex flex-col gap-3 mb-6">
         <span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">Wait until I have:</span>
         <input
+          ref="inputEl"
           v-model="targetInput"
           type="text"
           placeholder="e.g. 1M or 1,234,567"
@@ -98,6 +99,8 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+const inputEl = ref<HTMLInputElement | null>(null);
+defineExpose({ focus: () => inputEl.value?.focus() });
 import { iconURL } from 'lib';
 import { useVirtueStore } from '@/stores/virtue';
 import { useActionsStore } from '@/stores/actions';

--- a/wasmegg/ascension-planner/src/components/actions/WaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitForTEActions.vue
@@ -96,6 +96,7 @@
             </svg>
           </button>
           <input
+            ref="inputEl"
             v-model.number="teToGain"
             type="number"
             :min="1"
@@ -201,6 +202,8 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
+const inputEl = ref<HTMLInputElement | null>(null);
+defineExpose({ focus: () => inputEl.value?.focus() });
 import { iconURL } from 'lib';
 import { useTruthEggsStore } from '@/stores/truthEggs';
 import { useVirtueStore } from '@/stores/virtue';

--- a/wasmegg/ascension-planner/src/components/actions/WaitForTEActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitForTEActions.vue
@@ -134,7 +134,7 @@
         <div class="pt-2 mt-1 border-t border-slate-100/50 space-y-2">
           <div class="flex justify-between items-center text-[10px]">
             <div class="flex items-center gap-1">
-              <span class="font-black text-slate-400 uppercase tracking-widest">ELR per hour:</span>
+              <span class="font-black text-slate-400 uppercase tracking-widest">Delivery Rate per hour:</span>
               <button
                 class="p-0.5 text-slate-300 hover:text-slate-900 transition-colors"
                 v-tippy="'View calculation details'"
@@ -154,7 +154,7 @@
           </div>
           <div class="flex justify-between items-center text-[10px]">
             <div class="flex items-center gap-1">
-              <span class="font-black text-slate-400 uppercase tracking-widest">ELR per day:</span>
+              <span class="font-black text-slate-400 uppercase tracking-widest">Delivery Rate per day:</span>
             </div>
             <span class="font-mono-premium text-slate-500">{{ formatNumber(elrPerDay, 2) }}</span>
           </div>

--- a/wasmegg/ascension-planner/src/components/actions/WaitForTimeActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitForTimeActions.vue
@@ -5,6 +5,7 @@
         <label class="block text-[10px] font-black text-slate-400 uppercase tracking-widest mb-3"> Duration </label>
         <div class="flex flex-col sm:flex-row gap-2">
           <input
+            ref="inputEl"
             v-model="inputDuration"
             type="text"
             placeholder="e.g. 8h30m, 12:30pm, or +0"
@@ -84,6 +85,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { iconURL } from 'lib';
+const inputEl = ref<HTMLInputElement | null>(null);
+defineExpose({ focus: () => inputEl.value?.focus() });
 import { useActionsStore } from '@/stores/actions';
 import { useVirtueStore } from '@/stores/virtue';
 import { useActionExecutor } from '@/composables/useActionExecutor';

--- a/wasmegg/ascension-planner/src/components/actions/WaitWithoutEarningsActions.vue
+++ b/wasmegg/ascension-planner/src/components/actions/WaitWithoutEarningsActions.vue
@@ -5,6 +5,7 @@
         <label class="block text-[10px] font-black text-slate-400 uppercase tracking-widest mb-3"> Duration </label>
         <div class="flex flex-col sm:flex-row gap-2">
           <input
+            ref="inputEl"
             v-model="inputDuration"
             type="text"
             placeholder="e.g. 8 or 8h30m"
@@ -75,6 +76,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
 import { useActionsStore } from '@/stores/actions';
+const inputEl = ref<HTMLInputElement | null>(null);
+defineExpose({ focus: () => inputEl.value?.focus() });
 import { useVirtueStore } from '@/stores/virtue';
 import { useActionExecutor } from '@/composables/useActionExecutor';
 import { generateActionId } from '@/types';

--- a/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
@@ -139,55 +139,65 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-3 gap-x-1.5 sm:gap-x-6 gap-y-2 mb-3.5">
+      <div class="grid grid-cols-4 gap-x-1.5 sm:gap-x-3 gap-y-2 mb-3.5">
         <!-- TE Progress -->
         <div class="space-y-0.5">
-          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
             <div class="w-1 h-1 rounded-full bg-emerald-500"></div>
             TE Progress
           </div>
-          <div class="flex items-baseline gap-1 sm:gap-1.5">
+          <div class="flex items-baseline gap-0.5 sm:gap-1.5">
             <span class="text-sm sm:text-xl font-mono-premium font-black text-slate-400">{{ summary.startTE }}</span>
-            <svg class="w-2 h-2 sm:w-3.5 sm:h-3.5 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-1.5 h-1.5 sm:w-3.5 sm:h-3.5 text-slate-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3" />
             </svg>
             <span class="text-base sm:text-2xl font-mono-premium font-black text-emerald-600">{{ summary.endTE }}</span>
-            <img :src="iconURL('egginc/egg_truth.png', 64)" class="w-3 h-3 sm:w-4 sm:h-4 ml-0.5" alt="TE" />
           </div>
           <div class="text-[8px] sm:text-[9px] font-black text-emerald-500/80 uppercase tracking-tight mt-0.5">+{{ summary.teGained }}</div>
         </div>
 
         <!-- Peak ELR -->
         <div class="space-y-0.5">
-          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
             <div class="w-1 h-1 rounded-full bg-indigo-500"></div>
-            Peak Delivery Rate
+            <span class="sm:hidden">Delivery</span><span class="hidden sm:inline">Delivery Rate</span>
           </div>
-          <div class="flex items-center gap-1 sm:gap-1.5">
-            <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatNumber(summary.maxELR * 3600, 3) }}</span>
-            <span class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase">/HR</span>
+          <div class="flex items-center gap-0.5 sm:gap-1.5">
+            <span class="text-[11px] sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatNumber(summary.maxELR * 3600, 3) }}</span>
+            <span class="text-[6px] sm:text-[9px] font-black text-slate-400 uppercase">/HR</span>
           </div>
           <div v-if="summary.alternativeELRs && summary.alternativeELRs.length > 0" class="flex flex-col gap-0.5 mt-0.5">
             <div
               v-for="alt in summary.alternativeELRs"
               :key="alt.label"
-              class="flex items-baseline gap-1"
+              class="flex items-baseline gap-0.5 sm:gap-1"
             >
-              <span class="text-[9px] sm:text-[10px] font-mono-premium font-bold text-slate-400">{{ formatNumber(alt.elr * 3600, 3) }}</span>
-              <span class="text-[7px] sm:text-[8px] font-black text-slate-300 uppercase tracking-wide">/hr</span>
-              <span class="text-[7px] sm:text-[8px] font-black text-slate-400 uppercase tracking-wide">{{ alt.label }}</span>
+              <span class="text-[7px] sm:text-[10px] font-mono-premium font-bold text-slate-400">{{ formatNumber(alt.elr * 3600, 3) }}</span>
+              <span class="text-[6px] sm:text-[8px] font-black text-slate-300 uppercase tracking-wide">/hr</span>
+              <span class="text-[6px] sm:text-[8px] font-black text-slate-400 uppercase tracking-wide">{{ alt.label }}</span>
             </div>
           </div>
         </div>
 
         <!-- Total Duration -->
         <div class="space-y-0.5">
-          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
             <div class="w-1 h-1 rounded-full bg-indigo-600"></div>
             Duration
           </div>
           <div class="flex items-center gap-1 sm:gap-1.5">
             <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatDuration(summary.totalDurationSeconds) }}</span>
+          </div>
+        </div>
+
+        <!-- Longest Single TE Wait -->
+        <div v-if="summary.lastTEDurationSeconds > 0" class="space-y-0.5">
+          <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
+            <div class="w-1 h-1 rounded-full bg-indigo-400"></div>
+            Last TE Wait
+          </div>
+          <div class="flex items-center gap-1 sm:gap-1.5">
+            <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-500">{{ formatDuration(summary.lastTEDurationSeconds) }}</span>
           </div>
         </div>
       </div>
@@ -209,7 +219,7 @@
         <div class="grid grid-cols-3 gap-x-1.5 sm:gap-x-4 gap-y-2 bg-slate-50/50 border border-slate-100 rounded-xl p-2 sm:p-3">
           <!-- SE Cost -->
           <div class="space-y-0.5">
-            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
               <div class="w-1 h-1 rounded-full bg-rose-500"></div>
               SE Consumed
             </div>
@@ -221,7 +231,7 @@
 
           <!-- Ending SE Balance -->
           <div class="space-y-0.5">
-            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
               <div class="w-1 h-1 rounded-full bg-slate-400"></div>
               Ending SE Balance
             </div>
@@ -236,7 +246,7 @@
 
           <!-- Total Eggs Delivered -->
           <div class="space-y-0.5">
-            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
+            <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide flex items-center gap-1 sm:gap-1.5">
               <div class="w-1 h-1 rounded-full bg-slate-400"></div>
               Eggs Delivered
             </div>

--- a/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AscensionOverview.vue
@@ -161,7 +161,7 @@
         <div class="space-y-0.5">
           <div class="text-[7px] sm:text-[9px] font-black text-slate-400 uppercase tracking-wide sm:tracking-widest flex items-center gap-1 sm:gap-1.5">
             <div class="w-1 h-1 rounded-full bg-indigo-500"></div>
-            Peak ELR
+            Peak Delivery Rate
           </div>
           <div class="flex items-center gap-1 sm:gap-1.5">
             <span class="text-sm sm:text-xl font-mono-premium font-black text-indigo-600">{{ formatNumber(summary.maxELR * 3600, 3) }}</span>

--- a/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
+++ b/wasmegg/ascension-planner/src/components/auto/AutomaticPlanner.vue
@@ -91,8 +91,8 @@
               <li><span class="font-semibold">C2</span> — Maxes fleet size research. If it can afford Graviton Coupling within 4 hours, it does.</li>
               <li><span class="font-semibold">K2</span> — Max Vehicles and Hyperloop Train Cars.</li>
               <li><span class="font-semibold">R1</span> — Buys as many silos as possible within one hour.</li>
-              <li><span class="font-semibold">C3</span> — Purchases remaining ELR-boosting research: lay rate, shipping capacity, and hab capacity.</li>
-              <li><span class="font-semibold">H1</span> — Swaps to the optimal artifact loadout for ELR.</li>
+              <li><span class="font-semibold">C3</span> — Purchases remaining Delivery Rate-boosting research: lay rate, shipping capacity, and hab capacity.</li>
+              <li><span class="font-semibold">H1</span> — Swaps to the optimal artifact loadout for Delivery Rate.</li>
               <li><span class="font-semibold">K3</span> — Buys new hyperloop cars unlocked by C3, then waits out the ascension until the TE goal is reached.</li>
               <li><span class="font-semibold">C4 / I2 / R2 / H2</span> — Each shifts to its respective virtue egg and waits until that egg's share of the TE goal is met.</li>
             </ul>

--- a/wasmegg/ascension-planner/src/components/auto/ChainSummaryBar.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ChainSummaryBar.vue
@@ -100,9 +100,13 @@ function formatDateOnly(timestampSeconds: number, tz: string): string {
   if (!timestampSeconds) return 'N/A';
   const date = new Date(timestampSeconds * 1000);
   if (isNaN(date.getTime())) return 'N/A';
-  return date.toLocaleDateString('en-US', {
-    weekday: 'short', month: 'short', day: 'numeric', year: 'numeric', timeZone: tz,
-  });
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: 'short', month: 'short', day: 'numeric', timeZone: tz,
+  };
+  if (date.getFullYear() !== new Date().getFullYear()) {
+    options.year = 'numeric';
+  }
+  return date.toLocaleDateString('en-US', options);
 }
 
 const totals = computed(() => {

--- a/wasmegg/ascension-planner/src/components/auto/ForcedAscensionPreview.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ForcedAscensionPreview.vue
@@ -24,7 +24,7 @@
 
       <!-- Peak ELR row -->
       <div class="flex items-center gap-3 mb-4 px-1">
-        <span class="text-[9px] font-black text-slate-400 uppercase tracking-widest">Peak ELR</span>
+        <span class="text-[9px] font-black text-slate-400 uppercase tracking-widest">Peak Delivery Rate</span>
         <div class="flex items-center gap-1.5">
           <span class="text-[9px] font-black text-slate-500 uppercase tracking-wider">1-sale</span>
           <span class="text-[13px] font-mono-premium font-black text-indigo-600">

--- a/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
+++ b/wasmegg/ascension-planner/src/components/auto/ShiftSummary.vue
@@ -241,7 +241,7 @@ if (!(researchId in startResearch)) startResearch[researchId] = fromLevel;
         }
       }
     } else if (action.type === 'equip_artifact_set') {
-      const setName = action.payload.setName === 'earnings' ? 'Earnings' : 'ELR';
+      const setName = action.payload.setName === 'earnings' ? 'Earnings' : 'Delivery Rate';
       equippedSets.push(setName);
     }
   }
@@ -260,7 +260,7 @@ if (!(researchId in startResearch)) startResearch[researchId] = fromLevel;
     if (peakELRAction) {
       items.push({
         isPeakELR: true,
-        text: `Peak ELR: ${formatNumber(peakELRAction.payload.peakELR * 3600, 3)}/hr`,
+        text: `Peak Delivery Rate: ${formatNumber(peakELRAction.payload.peakELR * 3600, 3)}/hr`,
       });
     }
     // --- TE Earned ---

--- a/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
+++ b/wasmegg/ascension-planner/src/components/auto/VirtueProgressSection.vue
@@ -15,7 +15,7 @@
               +{{ truthEggsStore.totalPendingTE }} Pending
             </span>
             <span class="w-1 h-1 bg-slate-200 rounded-full"></span>
-            <span class="text-[10px] font-black text-slate-500">ELR {{ formatNumber(currentELR * 3600, 3) }}/hr</span>
+            <span class="text-[10px] font-black text-slate-500">Delivery Rate {{ formatNumber(currentELR * 3600, 3) }}/hr</span>
           </div>
         </div>
       </div>

--- a/wasmegg/ascension-planner/src/components/presenters/EarningsDisplay.vue
+++ b/wasmegg/ascension-planner/src/components/presenters/EarningsDisplay.vue
@@ -46,7 +46,7 @@
           <span class="font-mono-premium text-sm font-bold text-slate-700">{{ formatNumber(eggValue, 2) }}</span>
         </div>
         <div class="px-5 py-3 flex justify-between items-center group hover:bg-slate-50 transition-colors">
-          <span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">Effective Lay Rate</span>
+          <span class="text-[10px] font-black text-slate-400 uppercase tracking-widest">Delivery Rate</span>
           <span class="font-mono-premium text-sm font-bold text-slate-700"
             >{{ formatNumber(convertedELR, 2)
             }}<span class="text-[10px] opacity-60 ml-0.5">/{{ timeUnitLabel }}</span></span

--- a/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
+++ b/wasmegg/ascension-planner/src/components/presenters/InitialStateDisplay.vue
@@ -302,7 +302,7 @@
               class="btn-premium btn-primary py-2 text-[10px] font-black uppercase tracking-widest"
               @click="$emit('save-current-to-set', 'elr')"
             >
-              Save as ELR
+              Save as Delivery
             </button>
           </div>
         </template>

--- a/wasmegg/ascension-planner/src/components/summaries/CuriositySummary.vue
+++ b/wasmegg/ascension-planner/src/components/summaries/CuriositySummary.vue
@@ -14,7 +14,15 @@
             />
           </svg>
         </div>
-        <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Research Summary</span>
+        <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Curiosity Summary</span>
+        <div v-if="activeArtifactSet === 'earnings'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyOfflineEarnings, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
+        <div v-else-if="activeArtifactSet === 'elr'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyELR, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
       </div>
 
       <div v-if="totalResearchCost > 0" class="flex items-center gap-1.5 px-2 py-0.5 rounded-full bg-amber-50/50 border border-amber-100/50">
@@ -64,7 +72,7 @@
 import { computed } from 'vue';
 import type { Action, BuyResearchPayload } from '@/types';
 import { getResearchById, getResearchByTier } from '@/calculations/commonResearch';
-import { formatGemPrice } from '@/lib/format';
+import { formatGemPrice, formatNumber } from '@/lib/format';
 import { iconURL } from 'lib';
 
 import { useActionsStore } from '@/stores/actions';
@@ -83,6 +91,10 @@ const endState = computed(() => {
   }
   return props.headerAction.endState;
 });
+
+const activeArtifactSet = computed(() => endState.value.activeArtifactSet);
+const hourlyOfflineEarnings = computed(() => endState.value.offlineEarnings * 3600);
+const hourlyELR = computed(() => endState.value.elr * 3600);
 
 const totalResearchCost = computed(() => {
   return props.actions.reduce((acc, action) => {

--- a/wasmegg/ascension-planner/src/components/summaries/HumilitySummary.vue
+++ b/wasmegg/ascension-planner/src/components/summaries/HumilitySummary.vue
@@ -11,6 +11,14 @@
           </svg>
         </div>
         <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Humility Summary</span>
+        <div v-if="activeArtifactSet === 'earnings'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyOfflineEarnings, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
+        <div v-else-if="activeArtifactSet === 'elr'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyELR, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
         <div
           v-if="teGained > 0"
           class="badge-premium badge-success flex items-center gap-1 py-0.5 px-2 text-[10px]"
@@ -51,12 +59,23 @@
 import { computed } from 'vue';
 import { iconURL } from 'lib';
 import type { Action, LaunchMissionsPayload, WaitForTEPayload } from '@/types';
-import { formatDuration } from '@/lib/format';
+import { formatDuration, formatNumber } from '@/lib/format';
 
 const props = defineProps<{
   headerAction: Action;
   actions: Action[];
 }>();
+
+const finalState = computed(() => {
+  if (props.actions.length > 0) {
+    return props.actions[props.actions.length - 1].endState;
+  }
+  return props.headerAction.endState;
+});
+
+const activeArtifactSet = computed(() => finalState.value.activeArtifactSet);
+const hourlyOfflineEarnings = computed(() => finalState.value.offlineEarnings * 3600);
+const hourlyELR = computed(() => finalState.value.elr * 3600);
 
 /**
  * Calculate total missions launched in this period.

--- a/wasmegg/ascension-planner/src/components/summaries/IntegritySummary.vue
+++ b/wasmegg/ascension-planner/src/components/summaries/IntegritySummary.vue
@@ -16,6 +16,14 @@
           </svg>
         </div>
         <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Integrity Summary</span>
+        <div v-if="activeArtifactSet === 'earnings'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyOfflineEarnings, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
+        <div v-else-if="activeArtifactSet === 'elr'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyELR, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
         <div
           v-if="teGained > 0"
           class="badge-premium bg-indigo-100 text-indigo-700 border-indigo-200/50 flex items-center gap-1 py-0.5 px-2 text-[10px]"
@@ -73,6 +81,10 @@ const finalState = computed(() => {
   }
   return props.headerAction.endState;
 });
+
+const activeArtifactSet = computed(() => finalState.value.activeArtifactSet);
+const hourlyOfflineEarnings = computed(() => finalState.value.offlineEarnings * 3600);
+const hourlyELR = computed(() => finalState.value.elr * 3600);
 
 /**
  * Check if we have 4 Chicken Universes (ID 18).

--- a/wasmegg/ascension-planner/src/components/summaries/KindnessSummary.vue
+++ b/wasmegg/ascension-planner/src/components/summaries/KindnessSummary.vue
@@ -16,6 +16,14 @@
           </svg>
         </div>
         <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Kindness Summary</span>
+        <div v-if="activeArtifactSet === 'earnings'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyOfflineEarnings, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
+        <div v-else-if="activeArtifactSet === 'elr'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyELR, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
       </div>
 
       <!-- Stats Grid -->
@@ -66,6 +74,10 @@ const finalState = computed<CalculationsSnapshot>(() => {
   }
   return props.headerAction.endState;
 });
+
+const activeArtifactSet = computed(() => finalState.value.activeArtifactSet);
+const hourlyOfflineEarnings = computed(() => finalState.value.offlineEarnings * 3600);
+const hourlyELR = computed(() => finalState.value.elr * 3600);
 
 const isMaxed = computed(() => {
   const { vehicles, researchLevels } = finalState.value;

--- a/wasmegg/ascension-planner/src/components/summaries/ResilienceSummary.vue
+++ b/wasmegg/ascension-planner/src/components/summaries/ResilienceSummary.vue
@@ -16,6 +16,14 @@
           </svg>
         </div>
         <span class="text-[10px] font-black text-slate-400 uppercase tracking-[0.2em]">Resilience Summary</span>
+        <div v-if="activeArtifactSet === 'earnings'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyOfflineEarnings, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
+        <div v-else-if="activeArtifactSet === 'elr'" class="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-slate-100 border border-slate-200/50">
+          <span class="text-[9px] font-black font-mono-premium text-slate-700">{{ formatNumber(hourlyELR, 3) }}</span>
+          <span class="text-[8px] font-black uppercase tracking-widest text-slate-400">/hr</span>
+        </div>
       </div>
 
       <!-- Stats Grid -->
@@ -46,11 +54,23 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import type { Action } from '@/types';
+import { formatNumber } from '@/lib/format';
 
 const props = defineProps<{
   headerAction: Action;
   actions: Action[];
 }>();
+
+const finalState = computed(() => {
+  if (props.actions.length > 0) {
+    return props.actions[props.actions.length - 1].endState;
+  }
+  return props.headerAction.endState;
+});
+
+const activeArtifactSet = computed(() => finalState.value.activeArtifactSet);
+const hourlyOfflineEarnings = computed(() => finalState.value.offlineEarnings * 3600);
+const hourlyELR = computed(() => finalState.value.elr * 3600);
 
 const silosPurchased = computed(() => {
   return props.actions.filter(a => a.type === 'buy_silo').length;

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -108,6 +108,8 @@ const ELR_EXCLUDED_CATEGORIES = [
 
 
 
+const DELIVERY_IMPACT_CATEGORIES = new Set(['hab_capacity', 'fleet_size', 'egg_laying_rate', 'shipping_capacity']);
+
 export function useResearchViews() {
   const commonResearchStore = useCommonResearchStore();
   const initialStateStore = useInitialStateStore();
@@ -117,6 +119,7 @@ export function useResearchViews() {
   const currentView = ref<ViewType>('game');
   const elrViewMode = ref<ElrViewMode>('realistic');
   const elrSortMode = ref<ElrSortMode>('efficiency');
+  const deliveryImpactOnly = ref(false);
 
   const realisticSummary = computed(() => {
     const rawBackup = initialStateStore.rawBackup;
@@ -615,6 +618,11 @@ export function useResearchViews() {
             recommendationNote,
           };
         })
+        .filter(c => {
+          if (!deliveryImpactOnly.value) return true;
+          const cats = c.research.categories.split(',').map(s => s.trim());
+          return cats.some(cat => DELIVERY_IMPACT_CATEGORIES.has(cat));
+        })
         .sort((a, b) => {
           if (a.canBuy !== b.canBuy) return a.canBuy ? -1 : 1;
           if (a.totalRoiSeconds === b.totalRoiSeconds) {
@@ -841,6 +849,7 @@ export function useResearchViews() {
     currentView,
     elrViewMode,
     elrSortMode,
+    deliveryImpactOnly,
     viewDescription,
     costModifiers,
     isResearchSaleActive,

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -78,7 +78,7 @@ export const VIEWS = [
   { id: 'game', label: 'Game View' },
   { id: 'cheapest', label: 'Cheapest First' },
   { id: 'roi', label: 'Earnings ROI' },
-  { id: 'elr', label: 'ELR Impact' },
+  { id: 'elr', label: 'Delivery Impact' },
 ] as const;
 
 // Evaluation IDs for ELR Impact
@@ -154,13 +154,13 @@ export function useResearchViews() {
         const view = elrViewMode.value;
         const sort = elrSortMode.value;
         if (view === 'potential' && sort === 'efficiency') {
-          return 'Theoretical max impact to ELR, sorted by time efficiency.';
+          return 'Theoretical max impact to Delivery Rate, sorted by time efficiency.';
         } else if (view === 'potential' && sort === 'impact') {
-          return 'Theoretical max impact to ELR, sorted by total impact.';
+          return 'Theoretical max impact to Delivery Rate, sorted by total impact.';
         } else if (view === 'realistic' && sort === 'efficiency') {
-          return 'True ELR impact with optimal artifacts and max habs/vehicles, sorted by time efficiency.';
+          return 'True Delivery Rate impact with optimal artifacts and max habs/vehicles, sorted by time efficiency.';
         } else {
-          return 'True ELR impact with optimal artifacts and max habs/vehicles, sorted by total impact.';
+          return 'True Delivery Rate impact with optimal artifacts and max habs/vehicles, sorted by total impact.';
         }
       }
       default:
@@ -666,7 +666,7 @@ export function useResearchViews() {
         if (baseline.effectiveRate <= 0) return [];
 
         const baselineFmt = (n: number) => n.toExponential(3);
-        console.log(`[ELR View] Baseline (max Hyperloops): lay=${baselineFmt(baseline.layRate * 3600)}/hr, ship=${baselineFmt(baseline.shippingRate * 3600)}/hr, ELR=${baselineFmt(baseline.effectiveRate * 3600)}/hr — bottleneck: ${baseline.layRate < baseline.shippingRate ? 'LAY RATE' : 'SHIPPING'}`);
+        // console.log(`[ELR View] Baseline (max Hyperloops): lay=${baselineFmt(baseline.layRate * 3600)}/hr, ship=${baselineFmt(baseline.shippingRate * 3600)}/hr, ELR=${baselineFmt(baseline.effectiveRate * 3600)}/hr — bottleneck: ${baseline.layRate < baseline.shippingRate ? 'LAY RATE' : 'SHIPPING'}`);
 
         candidates = uniqueUnpurchased
           .map(r => {
@@ -756,7 +756,7 @@ export function useResearchViews() {
             if (DEBUG_IDS.includes(c.research.id) || c.impact > 0 || c.lookahead) {
               const stats = c.realisticStats!;
               const laNote = c.lookahead ? ` [lookahead ${c.lookahead.minLevels} levels → +${(c.lookahead.impact * 100).toFixed(4)}%]` : '';
-              console.log(`[ELR View] ${c.research.name}: impact=${(c.impact * 100).toFixed(4)}%, lay=${fmt(stats.layRate)}/hr, ship=${fmt(stats.shippingRate)}/hr, elr=${fmt(stats.elr)}/hr${laNote}`);
+              // console.log(`[ELR View] ${c.research.name}: impact=${(c.impact * 100).toFixed(4)}%, lay=${fmt(stats.layRate)}/hr, ship=${fmt(stats.shippingRate)}/hr, elr=${fmt(stats.elr)}/hr${laNote}`);
             }
             return c;
           })

--- a/wasmegg/ascension-planner/src/composables/useResearchViews.ts
+++ b/wasmegg/ascension-planner/src/composables/useResearchViews.ts
@@ -18,6 +18,7 @@ import { computeSnapshot } from '@/engine/compute';
 import { getSimulationContext, createBaseEngineState } from '@/engine/adapter';
 import { applyAction, applyTime, getTimeToSave, calculateEarningsForTime } from '@/engine/apply';
 import { calculateMaxVehicleSlots, calculateMaxTrainLength, calculateShippingCapacity } from '@/calculations/shippingCapacity';
+import type { SimulationContext } from '@/engine/types';
 import { getNextPacificTime } from '@/lib/events';
 import { type CalculationsSnapshot } from '@/types';
 import { getOptimalELRSet } from '@/lib/artifacts/virtue';
@@ -32,6 +33,23 @@ import { createSimAction } from '@/types/actions/meta';
 export type ViewType = 'game' | 'cheapest' | 'roi' | 'elr';
 export type ElrViewMode = 'realistic' | 'potential';
 export type ElrSortMode = 'efficiency' | 'impact';
+export type RoiMode = 'immediate' | 'maxed_vehicles';
+
+function buildMaxVehiclesSnapshot(
+  baseSnapshot: CalculationsSnapshot,
+  researchLevels: Record<string, number>,
+  context: SimulationContext
+): CalculationsSnapshot {
+  const maxSlots = calculateMaxVehicleSlots(researchLevels);
+  const maxTrainLen = calculateMaxTrainLength(researchLevels);
+  const engineState = createBaseEngineState(baseSnapshot);
+  const modifiedState = {
+    ...engineState,
+    researchLevels,
+    vehicles: Array(maxSlots).fill(null).map(() => ({ vehicleId: 11, trainLength: maxTrainLen })),
+  };
+  return computeSnapshot(modifiedState, context);
+}
 
 /**
  * Common interface for research items across different views.
@@ -120,6 +138,7 @@ export function useResearchViews() {
   const elrViewMode = ref<ElrViewMode>('realistic');
   const elrSortMode = ref<ElrSortMode>('efficiency');
   const deliveryImpactOnly = ref(false);
+  const roiMode = ref<RoiMode>('immediate');
 
   const realisticSummary = computed(() => {
     const rawBackup = initialStateStore.rawBackup;
@@ -510,6 +529,10 @@ export function useResearchViews() {
       const unpurchased = all.filter(r => (researchLevels[r.id] || 0) < r.levels && filterByCategories(r));
       const uniqueUnpurchased = Array.from(new Map(unpurchased.map(r => [r.id, r])).values());
 
+      const baseMaxVehiclesSnapshot = roiMode.value === 'maxed_vehicles'
+        ? buildMaxVehiclesSnapshot(effectiveSnapshot, researchLevels, context)
+        : null;
+
       const basicCandidates = uniqueUnpurchased.map(r => {
         const level = researchLevels[r.id] || 0;
         const price = getDiscountedVirtuePrice(r, level, mods, isSale);
@@ -518,22 +541,40 @@ export function useResearchViews() {
         const isLaying = categories.includes('egg_laying_rate');
         const isShipping = categories.includes('shipping_capacity');
 
-        const roiResult = calculateResearchROI({
-          research: r,
-          level,
-          price,
-          snapshot: effectiveSnapshot,
-          context,
-          eventTiming: {
-            absoluteSimTime,
-            nextSaleStart,
-            eventExpirationSeconds,
-            researchSaleDeadline: researchSaleDeadline.value,
-            isSaleActive: isSale,
-          },
-        });
+        let roiSeconds: number;
+        let totalRoiSeconds: number;
+        let showSaleWarning: boolean;
+        let showDeadlineWarning: boolean;
+        let resultTimeToBuySeconds: number;
+        let nextSnapshot: CalculationsSnapshot;
 
-        const { roiSeconds, totalRoiSeconds, showSaleWarning, showDeadlineWarning, timeToBuySeconds: resultTimeToBuySeconds, nextSnapshot } = roiResult;
+        if (roiMode.value === 'maxed_vehicles' && baseMaxVehiclesSnapshot) {
+          resultTimeToBuySeconds = getTimeToSave(price, effectiveSnapshot);
+          const afterMaxSnapshot = buildMaxVehiclesSnapshot(effectiveSnapshot, { ...researchLevels, [r.id]: level + 1 }, context);
+          nextSnapshot = afterMaxSnapshot;
+          const earningsDelta = afterMaxSnapshot.offlineEarnings - baseMaxVehiclesSnapshot.offlineEarnings;
+          roiSeconds = earningsDelta > 0 ? price / earningsDelta : Infinity;
+          totalRoiSeconds = isFinite(resultTimeToBuySeconds) ? resultTimeToBuySeconds + roiSeconds : Infinity;
+          showSaleWarning = !isSale && (absoluteSimTime + resultTimeToBuySeconds >= nextSaleStart);
+          showDeadlineWarning = isSale && (absoluteSimTime + resultTimeToBuySeconds > researchSaleDeadline.value);
+        } else {
+          const roiResult = calculateResearchROI({
+            research: r,
+            level,
+            price,
+            snapshot: effectiveSnapshot,
+            context,
+            eventTiming: {
+              absoluteSimTime,
+              nextSaleStart,
+              eventExpirationSeconds,
+              researchSaleDeadline: researchSaleDeadline.value,
+              isSaleActive: isSale,
+            },
+          });
+          ({ roiSeconds, totalRoiSeconds, showSaleWarning, showDeadlineWarning, nextSnapshot } = roiResult);
+          resultTimeToBuySeconds = roiResult.timeToBuySeconds;
+        }
 
         return {
           research: r,
@@ -574,37 +615,40 @@ export function useResearchViews() {
       return basicCandidates
         .map(c => {
           let recommendationNote: string | undefined = undefined;
-          const isBottlenecked = c.roiSeconds === Infinity || c.roiSeconds > 3600 * 24 * 7;
 
-          if (isBottlenecked && (c.isLaying || c.isShipping)) {
-            const partner = c.isLaying ? bestShipping : bestLaying;
-            if (partner && partner.research.id !== c.research.id) {
-              const level1 = researchLevels[c.research.id] || 0;
-              const level2 = researchLevels[partner.research.id] || 0;
+          if (roiMode.value === 'immediate') {
+            const isBottlenecked = c.roiSeconds === Infinity || c.roiSeconds > 3600 * 24 * 7;
 
-              let pairState = applyAction(baseState, createSimAction('buy_research', {
-                researchId: c.research.id,
-                fromLevel: level1,
-                toLevel: level1 + 1,
-              }, c.price));
+            if (isBottlenecked && (c.isLaying || c.isShipping)) {
+              const partner = c.isLaying ? bestShipping : bestLaying;
+              if (partner && partner.research.id !== c.research.id) {
+                const level1 = researchLevels[c.research.id] || 0;
+                const level2 = researchLevels[partner.research.id] || 0;
 
-              pairState = applyAction(pairState, createSimAction('buy_research', {
-                researchId: partner.research.id,
-                fromLevel: level2,
-                toLevel: level2 + 1,
-              }, partner.price));
+                let pairState = applyAction(baseState, createSimAction('buy_research', {
+                  researchId: c.research.id,
+                  fromLevel: level1,
+                  toLevel: level1 + 1,
+                }, c.price));
 
-              const pairSnapshot = computeSnapshot(pairState, context);
-              const pairEarnings = pairSnapshot.offlineEarnings;
-              const partnerEarnings = partner.nextSnapshot.offlineEarnings;
+                pairState = applyAction(pairState, createSimAction('buy_research', {
+                  researchId: partner.research.id,
+                  fromLevel: level2,
+                  toLevel: level2 + 1,
+                }, partner.price));
 
-              if (pairEarnings > partnerEarnings) {
-                const pairTotalCost = c.price + partner.price;
-                const pairDelta = pairEarnings - currentEarnings;
-                const pairRoiSeconds = pairTotalCost / pairDelta;
+                const pairSnapshot = computeSnapshot(pairState, context);
+                const pairEarnings = pairSnapshot.offlineEarnings;
+                const partnerEarnings = partner.nextSnapshot.offlineEarnings;
 
-                if (pairRoiSeconds < c.roiSeconds) {
-                  recommendationNote = `Buying this with "${partner.research.name}" would have a much better combined payback time of ${formatDuration(pairRoiSeconds)}.`;
+                if (pairEarnings > partnerEarnings) {
+                  const pairTotalCost = c.price + partner.price;
+                  const pairDelta = pairEarnings - currentEarnings;
+                  const pairRoiSeconds = pairTotalCost / pairDelta;
+
+                  if (pairRoiSeconds < c.roiSeconds) {
+                    recommendationNote = `Buying this with "${partner.research.name}" would have a much better combined payback time of ${formatDuration(pairRoiSeconds)}.`;
+                  }
                 }
               }
             }
@@ -850,6 +894,7 @@ export function useResearchViews() {
     elrViewMode,
     elrSortMode,
     deliveryImpactOnly,
+    roiMode,
     viewDescription,
     costModifiers,
     isResearchSaleActive,

--- a/wasmegg/ascension-planner/src/engine/compute.ts
+++ b/wasmegg/ascension-planner/src/engine/compute.ts
@@ -29,7 +29,7 @@ const BASE_EGG_VALUE = 1;
 export function computeSnapshot(
   state: EngineState,
   context: SimulationContext,
-  options: { skipGrowth?: boolean } = {}
+  options: { skipGrowth?: boolean; skipEpochConversion?: boolean } = {}
 ): SimulationResult {
   const { epicResearchLevels, colleggtibleModifiers } = context;
 
@@ -80,8 +80,10 @@ export function computeSnapshot(
     bankValue = state.bankValue || 0;
   } else {
     // 8. Population growth (catch-up if starting from a backup)
-    // If time is not initialized (e.g. fresh ascension), base it on the planned start time
-    if (lastStepTime < 1e9 && context.ascensionStartTime > 1e9) {
+    // If time is not initialized (e.g. fresh ascension), base it on the planned start time.
+    // Skip this when called from simulation loops (skipEpochConversion:true) to keep lastStepTime
+    // in the same relative reference frame as the rest of the plan.
+    if (!options.skipEpochConversion && lastStepTime < 1e9 && context.ascensionStartTime > 1e9) {
       lastStepTime = context.ascensionStartTime;
     }
 

--- a/wasmegg/ascension-planner/src/engine/simulate.ts
+++ b/wasmegg/ascension-planner/src/engine/simulate.ts
@@ -38,7 +38,9 @@ export function simulate(
   // We need a way to treat baseState as a Snapshot for delta computation of the first action.
   // However, computeDeltas expects a full CalculationsSnapshot.
   // We can compute the "base snapshot" once.
-  const baseSnapshot = computeSnapshot(baseState, context);
+  // skipEpochConversion keeps lastStepTime in the plan's native reference frame (relative or epoch)
+  // so that mid-plan recalculations don't corrupt the plan's time axis.
+  const baseSnapshot = computeSnapshot(baseState, context, { skipEpochConversion: true });
 
   let currentState = baseState;
   let currentSnapshot = baseSnapshot;
@@ -67,6 +69,7 @@ export function simulate(
     // 2. Compute full snapshot
     const newSnapshot = computeSnapshot(currentState, context, {
       skipGrowth: action.type === 'wait_for_no_earnings',
+      skipEpochConversion: true,
     });
 
     // 3. Compute deltas vs previous state
@@ -120,7 +123,7 @@ export async function simulateAsync(
 ): Promise<Action[]> {
   const results: Action[] = [];
   let previousSnapshot: CalculationsSnapshot | null = null;
-  const baseSnapshot = computeSnapshot(baseState, context);
+  const baseSnapshot = computeSnapshot(baseState, context, { skipEpochConversion: true });
 
   let currentState = baseState;
   let currentSnapshot = baseSnapshot;
@@ -152,6 +155,7 @@ export async function simulateAsync(
 
     const newSnapshot = computeSnapshot(currentState, context, {
       skipGrowth: action.type === 'wait_for_no_earnings',
+      skipEpochConversion: true,
     });
     const prevSnap = i === 0 ? baseSnapshot : previousSnapshot!;
     const deltas = computeDeltas(prevSnap, newSnapshot);

--- a/wasmegg/ascension-planner/src/lib/actions/executors/equipArtifactSet.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/executors/equipArtifactSet.ts
@@ -13,12 +13,12 @@ export const equipArtifactSetExecutor: ActionExecutor<'equip_artifact_set'> = {
   },
 
   getDisplayName(payload) {
-    const name = payload.setName === 'earnings' ? 'Earnings' : 'ELR';
+    const name = payload.setName === 'earnings' ? 'Earnings' : 'Delivery';
     return `Equip ${name} Set`;
   },
 
   getEffectDescription(payload) {
-    const name = payload.setName === 'earnings' ? 'Earnings' : 'ELR';
+    const name = payload.setName === 'earnings' ? 'Earnings' : 'Delivery';
     return `Switched to ${name} artifact loadout.`;
   },
 };

--- a/wasmegg/ascension-planner/src/lib/actions/executors/updateArtifactSet.ts
+++ b/wasmegg/ascension-planner/src/lib/actions/executors/updateArtifactSet.ts
@@ -20,7 +20,7 @@ export const updateArtifactSetExecutor: ActionExecutor<'update_artifact_set'> = 
   },
 
   getDisplayName(payload) {
-    const name = payload.setName === 'earnings' ? 'Earnings' : 'ELR';
+    const name = payload.setName === 'earnings' ? 'Earnings' : 'Delivery';
     return `Update ${name} Set`;
   },
 


### PR DESCRIPTION
Manual AP
✅  Rename ELR to Delivery Rate
✅  In Shift Actions, show how many shifts a player can afford before they go broke
✅  Show year in footers if it's not this year
✅  In Shift Summaries, show earnings rate or delivery rate in shift summaries based on which artifact set they have equipped
✅  Show a header that shows what button you clicked or which plan you loaded
✅  Focus the inputs for simple Wait actions like "Wait for Time" when they're expanded
✅  Add filters on Earnings ROI tab. 1) Only Delivery Rate research. 2) Show Achieve ROI based on assumed maxed vehicles.
✅ Fix bug where removing a research from an imported plan increased duration by years
Auto AP
✅ Show longest wait time for a single TE