### PR TITLE
Unify CTE calcs, show equipped arti CTE in virtue-companion

### DIFF
--- a/lib/sandbox/index.ts
+++ b/lib/sandbox/index.ts
@@ -36,6 +36,10 @@ export function farmToSandboxConfig(farm: Farm, override?: FarmToSandboxConfigOv
   const epicMultiplierResearch =
     farm.maxRunningChickenBonusResearches[farm.maxRunningChickenBonusResearches.length - 1];
   const missingEpicMultiplier = epicMultiplierResearch.maxLevel - epicMultiplierResearch.level;
+  const labUpgradeResearch = farm.researches([
+    { id: 'cheaper_research', name: 'Lab Upgrade', maxLevel: 10, perLevel: -0.05 },
+  ])[0];
+  const missingLabUpgrade = labUpgradeResearch.maxLevel - labUpgradeResearch.level;
   const config: IConfig = {
     prophecyEggs: getNumProphecyEggs(backup),
     truthEggs: getNumTruthEggs(backup),
@@ -47,6 +51,7 @@ export function farmToSandboxConfig(farm: Farm, override?: FarmToSandboxConfigOv
     missingSoulFood,
     missingProphecyBonus,
     missingEpicMultiplier,
+    missingLabUpgrade,
 
     birdFeedActive: override?.birdFeedActive ?? true,
     tachyonPrismActive: override?.tachyonPrismActive ?? true,

--- a/lib/sandbox/schema.proto
+++ b/lib/sandbox/schema.proto
@@ -34,6 +34,7 @@ message Config {
   uint32 missing_soul_food = 20;
   uint32 missing_prophecy_bonus = 21;
   uint32 missing_epic_multiplier = 22;
+  uint32 missing_lab_upgrade = 23;
 
   bool bird_feed_active = 10;
   bool tachyon_prism_active = 11;

--- a/lib/virtue.ts
+++ b/lib/virtue.ts
@@ -21,6 +21,21 @@ export function multiplierToTE(multiplier: number): number {
 }
 
 /**
+ * Calculate the Clothed Truth Egg contribution of the Lab Upgrade epic research.
+ * Lab Upgrade reduces research cost by 5% per level (max level 10 = 50% discount).
+ * The returned value is the penalty relative to a maxed Lab Upgrade: a fully-researched
+ * player contributes 0, while missing levels yield a negative TE.
+ *
+ * @param labUpgrade - The player's Lab Upgrade level (0-10)
+ * @returns The TE equivalent value of the (missing) Lab Upgrade discount (<= 0)
+ */
+export function cteFromLabUpgrade(labUpgrade: number): number {
+  const maxLabUpgradeMultiplier = 1 + 10 * -0.05; // max level 10, -5% per level
+  const labUpgradeMultiplier = 1 + labUpgrade * -0.05;
+  return multiplierToTE(maxLabUpgradeMultiplier / labUpgradeMultiplier);
+}
+
+/**
  * Calculate the Clothed Truth Egg value of artifacts only.
  * This returns the TE bonus from artifacts without considering colleggtibles or epic research.
  *
@@ -31,7 +46,6 @@ export function cteFromArtifacts(artifacts: Artifact[]): number {
   const eggValueMult = eggValueMultiplier(artifacts);
   const awayEarningsMult = awayEarningsMultiplier(artifacts);
   const researchPriceMult = researchPriceMultiplierFromArtifacts(artifacts);
-  console.log(researchPriceMult);
   const researchDiscountEffect = 1 / researchPriceMult;
 
   // Combine all artifact multipliers

--- a/wasmegg/artifact-sandbox/src/components/ArtifactSetsEffects.vue
+++ b/wasmegg/artifact-sandbox/src/components/ArtifactSetsEffects.vue
@@ -36,6 +36,13 @@
               <span class="Prophecy">{{ builds.config.prophecyBonus }} / 5</span>
             </span>
           </div>
+          <div v-if="builds.config.labUpgrade < 10" class="flex whitespace-nowrap">
+            <img :src="iconURL('egginc/r_icon_lab_upgrade.png', 64)" class="inline h-6 w-6 -mt-0.5" />
+            <span class="text-sm">
+              Lab upgrade
+              <span class="Soul">{{ builds.config.labUpgrade }} / 10</span>
+            </span>
+          </div>
         </template>
       </div>
     </div>

--- a/wasmegg/artifact-sandbox/src/components/TheConfigurator.vue
+++ b/wasmegg/artifact-sandbox/src/components/TheConfigurator.vue
@@ -152,6 +152,20 @@
               />
               <div class="absolute inset-y-0.5 right-0 pr-2.5 pt-1 pb-0.5 sm:text-sm text-gray-200">/ 5</div>
             </div>
+            <div class="relative flex items-center justify-end">
+              <label for="lab_upgrade" class="flex items-center text-sm whitespace-nowrap mr-2">
+                <img :src="iconURL('egginc/r_icon_lab_upgrade.png', 64)" class="h-8 w-8 relative -top-px" />
+                Lab upgrade
+              </label>
+              <integer-input
+                id="lab_upgrade"
+                v-model="conf.labUpgrade"
+                :min="0"
+                :max="10"
+                base-class="w-16 pl-2.5 pt-1 pb-0.5"
+              />
+              <div class="absolute inset-y-0.5 right-0 pr-2.5 pt-1 pb-0.5 sm:text-sm text-gray-200">/ 10</div>
+            </div>
           </div>
         </div>
 

--- a/wasmegg/artifact-sandbox/src/lib/effects/earning_bonus.ts
+++ b/wasmegg/artifact-sandbox/src/lib/effects/earning_bonus.ts
@@ -2,7 +2,7 @@ import { Build, Config } from '../models';
 import { ArtifactSpec } from '../proto';
 import { allColleggtiblesModifiers } from './colleggtibles';
 import { additiveEffect } from './common';
-import { cteFromArtifacts, cteFromColleggtibles, multiplierToTE } from 'lib';
+import { cteFromArtifacts, cteFromColleggtibles, cteFromLabUpgrade, multiplierToTE } from 'lib';
 
 export function earningBonus(build: Build, config: Config, virtue = false): number {
   const peBonus = prophecyEggBonus(build, config);
@@ -29,8 +29,10 @@ export function clothedTE(build: Build, config: Config) {
   const cteFromColleggs = cteFromColleggtibles(modifiers);
   // cte penalty for std permit
   const cteFromPermit = config.proPermit ? 0 : multiplierToTE(0.5);
+  // cte penalty for missing Lab Upgrade epic research
+  const cteFromLab = cteFromLabUpgrade(config.labUpgrade);
 
-  return cteFromArtis + cteFromColleggs + cteFromPermit;
+  return cteFromArtis + cteFromColleggs + cteFromPermit + cteFromLab;
 }
 
 function prophecyEggBonus(build: Build, config: Config): number {

--- a/wasmegg/artifact-sandbox/src/lib/effects/research_price.ts
+++ b/wasmegg/artifact-sandbox/src/lib/effects/research_price.ts
@@ -5,6 +5,8 @@ import { colleggtibleModifier } from './colleggtibles';
 import { ei } from 'lib';
 
 export function researchPriceMultiplier(build: Build, config: Config): number {
+  // Lab Upgrade epic research: -5% research cost per level (max level 10 = 50% off).
+  const labUpgradeMultiplier = 1 + config.labUpgrade * -0.05;
   return (
     aggregateEffect(
       build,
@@ -15,7 +17,9 @@ export function researchPriceMultiplier(build: Build, config: Config): number {
           ? (1 + effect.delta * effect.multiplier) * aggregate
           : ((1 + effect.delta) / effect.multiplier) * aggregate,
       1
-    ) * colleggtibleModifier(config, ei.GameModifier.GameDimension.RESEARCH_COST)
+    ) *
+    colleggtibleModifier(config, ei.GameModifier.GameDimension.RESEARCH_COST) *
+    labUpgradeMultiplier
   );
 }
 

--- a/wasmegg/artifact-sandbox/src/lib/models.ts
+++ b/wasmegg/artifact-sandbox/src/lib/models.ts
@@ -361,6 +361,7 @@ export class Stone {
 
 const maxSoulFood = 140;
 const maxProphecyBonus = 5;
+const maxLabUpgrade = 10;
 const maxRCB = 540;
 
 export class Config {
@@ -372,6 +373,7 @@ export class Config {
   isVirtue: boolean;
   soulFood: number;
   prophecyBonus: number;
+  labUpgrade: number;
   RCB: number;
   birdFeedActive: boolean;
   tachyonPrismActive: boolean;
@@ -390,6 +392,7 @@ export class Config {
     this.isVirtue = false;
     this.soulFood = maxSoulFood;
     this.prophecyBonus = maxProphecyBonus;
+    this.labUpgrade = maxLabUpgrade;
     this.RCB = maxRCB;
     this.birdFeedActive = false;
     this.tachyonPrismActive = false;
@@ -423,6 +426,7 @@ export class Config {
     self.truthEggs = config?.truthEggs ?? 0;
     self.soulFood = maxSoulFood - (config?.missingSoulFood ?? 0);
     self.prophecyBonus = maxProphecyBonus - (config?.missingProphecyBonus ?? 0);
+    self.labUpgrade = maxLabUpgrade - (config?.missingLabUpgrade ?? 0);
     self.RCB = maxRCB;
     self.birdFeedActive = config?.birdFeedActive ?? false;
     self.tachyonPrismActive = config?.tachyonPrismActive ?? false;
@@ -444,6 +448,7 @@ export class Config {
       truthEggs: this.truthEggs,
       missingSoulFood: maxSoulFood - this.soulFood,
       missingProphecyBonus: maxProphecyBonus - this.prophecyBonus,
+      missingLabUpgrade: maxLabUpgrade - this.labUpgrade,
       birdFeedActive: this.birdFeedActive,
       tachyonPrismActive: this.tachyonPrismActive,
       soulBeaconActive: this.soulBeaconActive,
@@ -455,7 +460,12 @@ export class Config {
   }
 
   epicResearchMaxed(): boolean {
-    return this.soulFood === maxSoulFood && this.prophecyBonus === maxProphecyBonus && this.RCB === maxRCB;
+    return (
+      this.soulFood === maxSoulFood &&
+      this.prophecyBonus === maxProphecyBonus &&
+      this.labUpgrade === maxLabUpgrade &&
+      this.RCB === maxRCB
+    );
   }
 
   anyBoostActive(): boolean {

--- a/wasmegg/virtue-companion/src/components/TheCompanion.vue
+++ b/wasmegg/virtue-companion/src/components/TheCompanion.vue
@@ -180,7 +180,7 @@
       <hr />
 
       <collapsible-section
-        section-title="Currently Equipped Artifacts"
+        :section-title="`Currently Equipped Artifacts (Clothed TE: ${formatWithThousandSeparators(Math.round(clothedTE))})`"
         :visible="isVisibleSection('artifacts')"
         class="my-2 text-sm"
         @toggle="toggleSectionVisibility('artifacts')"

--- a/wasmegg/virtue-companion/src/lib/farmcalc/earnings.ts
+++ b/wasmegg/virtue-companion/src/lib/farmcalc/earnings.ts
@@ -3,7 +3,6 @@ import {
   Artifact,
   Stone,
   Modifiers,
-  maxModifierFromColleggtibles,
   allModifiersFromColleggtibles,
   getNumTruthEggs,
   recommendArtifactSet,
@@ -12,14 +11,18 @@ import {
   contenderToArtifactSet,
   ArtifactSet,
   Inventory,
+  cteFromArtifacts,
+  cteFromColleggtibles,
+  cteFromLabUpgrade,
+  multiplierToTE,
 } from 'lib';
-import { awayEarningsMultiplier, eggValueMultiplier, researchPriceMultiplierFromArtifacts } from '../effects';
+import { awayEarningsMultiplier } from '../effects';
 import { farmEarningBonus } from './earning_bonus';
 import { farmEggValue, farmEggValueResearches } from './egg_value';
 import { farmEggLayingRate } from './laying_rate';
 import { farmMaxRCB, farmMaxRCBResearches } from './max_rcb';
 import { farmShippingCapacity } from './shipping_capacity';
-import { researchPriceMultiplierFromResearches } from './research_price';
+import { labUpgradeLevel } from './research_price';
 import { homeFarmArtifacts } from './artifacts';
 
 export function farmEarningRate(
@@ -76,56 +79,23 @@ export function calculateClothedTE(
   const progress = backup.game!;
   const artifacts = artifactsOverride ?? homeFarmArtifacts(backup, true);
   const truthEggs = getNumTruthEggs(backup);
-
-  // Get current modifiers from colleggtibles (or use override)
   const currentModifiers = currentModifiersOverride ?? allModifiersFromColleggtibles(backup);
 
-  // Get max possible modifiers from colleggtibles
-  const maxEarningsModifier = maxModifierFromColleggtibles(ei.GameModifier.GameDimension.EARNINGS);
-  const maxAwayEarningsModifier = maxModifierFromColleggtibles(ei.GameModifier.GameDimension.AWAY_EARNINGS);
-  const maxResearchCostModifier = maxModifierFromColleggtibles(ei.GameModifier.GameDimension.RESEARCH_COST);
+  // Standard permit halves offline earnings.
+  const permitPenalty = progress.permitLevel === 1 ? 0 : multiplierToTE(0.5);
 
-  // Calculate multipliers from artifacts
-  const eggValueMult = eggValueMultiplier(artifacts);
-  const awayEarningsMult = awayEarningsMultiplier(artifacts);
-  const artifactResearchPriceMult = researchPriceMultiplierFromArtifacts(artifacts);
-
-  // Calculate epic research multiplier (Lab Upgrade) - actual level from backup
-  const epicResearchMult = researchPriceMultiplierFromResearches(farm, progress);
-  const maxEpicResearchMult = 1 + 10 * -0.05; // Max level 10, -5% per level = 0.5 (50% discount)
-
-  // Standard permit penalty (50% offline earnings)
-  const permitMult = progress.permitLevel === 1 ? 1 : 0.5;
-
-  // Calculate effective multipliers
-  // For earnings sources (egg value, offline earnings), higher is better
-  const earningsEffect = eggValueMult * awayEarningsMult;
-
-  // For cost modifiers, we want to know what fraction of max discount we have
-  // Research discount is multiplicative, so we convert to "effective earnings boost"
-  // A 50% research discount (0.5x) is equivalent to 2x effective earnings (1/0.5 = 2)
-  const currentResearchPriceMult = artifactResearchPriceMult * epicResearchMult * currentModifiers.researchCost;
-  const researchDiscountEffect = 1 / currentResearchPriceMult;
-  const maxResearchDiscountEffect = 1 / (maxEpicResearchMult * maxResearchCostModifier);
-
-  // Calculate colleggtible penalties
-  // These represent what fraction of max power we have
-  const earningsPenalty = currentModifiers.earnings / maxEarningsModifier;
-  const awayEarningsPenalty = currentModifiers.awayEarnings / maxAwayEarningsModifier;
-  const researchCostPenalty = researchDiscountEffect / maxResearchDiscountEffect;
-
-  // Combine all multipliers
-  // This represents the total earnings multiplier from all sources
-  const totalMultiplier = earningsEffect * permitMult * earningsPenalty * awayEarningsPenalty * researchCostPenalty;
-
-  // Convert multiplier to TE equivalent
-  // Since TE affects earnings by 1.1^TE, we use logarithms to convert back:
-  // If earnings = 1.1^TE_base * multiplier, then
-  // equivalent TE = TE_base + log(multiplier) / log(1.1)
-  const multiplierAsTE = Math.log(totalMultiplier) / Math.log(1.1);
-  const clothedTE = truthEggs + multiplierAsTE;
-
-  return clothedTE;
+  // Composed from the shared lib CTE primitives so the Artifact Sandbox and
+  // Virtue Companion compute Clothed TE identically. Each term is the TE
+  // equivalent of one contribution: artifact multipliers (bonus), missing
+  // colleggtibles (penalty vs max), missing Lab Upgrade (penalty vs max), and
+  // the standard-permit penalty.
+  return (
+    truthEggs +
+    cteFromArtifacts(artifacts) +
+    cteFromColleggtibles(currentModifiers) +
+    cteFromLabUpgrade(labUpgradeLevel(farm, progress)) +
+    permitPenalty
+  );
 }
 
 /**

--- a/wasmegg/virtue-companion/src/lib/farmcalc/research_price.ts
+++ b/wasmegg/virtue-companion/src/lib/farmcalc/research_price.ts
@@ -2,14 +2,15 @@ import { ei, Artifact } from 'lib';
 import { farmResearch } from './common';
 import { researchPriceMultiplierFromArtifacts } from '../effects';
 
+const LAB_UPGRADE = { id: 'cheaper_research', name: 'Lab Upgrade', maxLevel: 10, perLevel: -0.05 };
+
 export function researchPriceMultiplierFromResearches(farm: ei.Backup.ISimulation, progress: ei.Backup.IGame): number {
-  const research = farmResearch(farm, progress, {
-    id: 'cheaper_research',
-    name: 'Lab Upgrade',
-    maxLevel: 10,
-    perLevel: -0.05,
-  });
+  const research = farmResearch(farm, progress, LAB_UPGRADE);
   return 1 + (research ? research.level * research.perLevel : 0);
+}
+
+export function labUpgradeLevel(farm: ei.Backup.ISimulation, progress: ei.Backup.IGame): number {
+  return farmResearch(farm, progress, LAB_UPGRADE)?.level ?? 0;
 }
 
 /**


### PR DESCRIPTION
Adds a Lab Upgrade epic-research input to the Artifact Sandbox that feeds Clothed TE and the research-cost discount, persisted in the share-link proto (missing_lab_upgrade,  backward-compatible — old links default to max, so existing CTE is unchanged).
 
Virtue Companion now shows the Clothed TE of your currently-equipped artifacts in the "Currently Equipped Artifacts" section header (previously only the "Optimal Artifacts" section  showed a CTE value).

Also factors the CTE math into shared lib (cteFromLabUpgrade) and points Virtue Companion's calculateClothedTE at the shared primitives so both tools compute it identically. That  reconciliation incidentally fixes a bug where VC counted Light of Eggendil toward virtue egg value (it's Enlightenment-only).